### PR TITLE
chore: publish as v0.3.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2022-02-18
+
+- Add `AsyncDB` API support.
+- Add file-level sort mode control statement.
+
 ## [0.2.0] - 2022-01-12
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqllogictest"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Sqllogictest parser and runner."
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add the following lines to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-sqllogictest = "0.2"
+sqllogictest = "0.3"
 ```
 
 Implement `DB` trait for your database structure:


### PR DESCRIPTION
We are going to publish the current version as v0.3.0.