### PR TITLE
feat: support evaluating `skipif` and `onlyif` conditions

### DIFF
--- a/examples/condition.rs
+++ b/examples/condition.rs
@@ -1,0 +1,41 @@
+use std::path::Path;
+
+pub struct FakeDB {
+    engine_name: &'static str,
+}
+
+#[derive(Debug)]
+pub struct FakeDBError;
+
+impl std::fmt::Display for FakeDBError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for FakeDBError {}
+
+impl sqllogictest::DB for FakeDB {
+    type Error = FakeDBError;
+
+    fn run(&mut self, sql: &str) -> Result<String, FakeDBError> {
+        if sql.contains(self.engine_name) {
+            Ok("Alice\nBob\nEve".into())
+        } else {
+            Err(FakeDBError)
+        }
+    }
+
+    fn engine_name(&self) -> &str {
+        &self.engine_name
+    }
+}
+
+fn main() {
+    let script = std::fs::read_to_string(Path::new("examples/condition.slt")).unwrap();
+
+    for engine_name in ["risinglight", "otherdb"] {
+        let mut tester = sqllogictest::Runner::new(FakeDB { engine_name });
+        tester.run_script(&script).unwrap();
+    }
+}

--- a/examples/condition.rs
+++ b/examples/condition.rs
@@ -27,7 +27,7 @@ impl sqllogictest::DB for FakeDB {
     }
 
     fn engine_name(&self) -> &str {
-        &self.engine_name
+        self.engine_name
     }
 }
 

--- a/examples/condition.slt
+++ b/examples/condition.slt
@@ -1,0 +1,24 @@
+onlyif risinglight
+statement ok
+create table risinglight_t(v1 int not null)
+
+skipif risinglight
+statement ok
+create table otherdb_t(v1 int not null)
+
+
+onlyif risinglight
+query I
+select * from risinglight_t
+----
+Alice
+Bob
+Eve
+
+skipif risinglight
+query I
+select * from otherdb_t
+----
+Alice
+Bob
+Eve

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,10 @@ struct Opt {
     #[clap()]
     files: String,
 
+    /// The database engine name, used by the record conditions.
+    #[clap(short, long, default_value = "postgresql")]
+    engine: String,
+
     /// The database server host.
     #[clap(short, long, default_value = "localhost")]
     host: String,
@@ -48,6 +52,7 @@ fn main() {
 
     let pg = Postgres {
         client: Arc::new(Mutex::new(client)),
+        engine_name: opt.engine.clone(),
     };
     let tests = files
         .map(|file| Test {
@@ -82,6 +87,8 @@ fn run_test(test: &Test<Postgres>) -> Outcome {
 #[derive(Clone)]
 struct Postgres {
     client: Arc<Mutex<postgres::Client>>,
+
+    engine_name: String,
 }
 
 impl sqllogictest::DB for Postgres {
@@ -117,5 +124,9 @@ impl sqllogictest::DB for Postgres {
             writeln!(output).unwrap();
         }
         Ok(output)
+    }
+
+    fn engine_name(&self) -> &str {
+        &self.engine_name
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn main() {
 
     let pg = Postgres {
         client: Arc::new(Mutex::new(client)),
-        engine_name: opt.engine.clone(),
+        engine_name: opt.engine,
     };
     let tests = files
         .map(|file| Test {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -17,7 +17,9 @@ pub trait AsyncDB: Send {
     async fn run(&mut self, sql: &str) -> Result<String, Self::Error>;
 
     /// Engine name of current database.
-    fn engine_name(&self) -> &str;
+    fn engine_name(&self) -> &str {
+        ""
+    }
 }
 
 /// The database to be tested.


### PR DESCRIPTION
This PR add the support of evaluating `skipif` and `onlyif` conditions for the runner. 
[References.](https://github.com/gregrahn/sqllogictest/blob/2777692befa12f626c76c29e3111b68888ffbb06/src/sqllogictest.c#L467-L491
)

For binary, we can specify the engine name by a new command-line argument of `--engine`. The default value is `postgresql`.