### PR TITLE
feat: support parallel sqllogictest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [0.4.0] - 2022-06-07
+
+### Added
+
+- Support parallel sqllogictest
+
 ## [0.3.4] - 2022-04-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqllogictest"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 description = "Sqllogictest parser and runner."
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["sql", "database", "parser", "cli"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-bin = ["anyhow", "console", "tokio-postgres", "env_logger", "glob", "clap", "tokio"]
+bin = ["anyhow", "console", "tokio-postgres", "env_logger", "glob", "clap", "tokio", "futures"]
 
 [dependencies]
 anyhow = { version = "1", optional = true }
@@ -19,6 +19,7 @@ async-trait = "0.1"
 clap = { version = "3", features = ["derive", "env"], optional = true }
 console = { version = "0.15", optional = true }
 env_logger = { version = "0.9", optional = true }
+futures = { version = "0.3", default-features = false, optional = true }
 futures-lite = "1"
 glob = { version = "0.3", optional = true }
 humantime = "2"


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

With `--jobs x` parameter, sqllogictest will create a database for each test file, and run them in parallel. Test UI remains the same, except that result will be printed to stdout only when one task ends.

<img width="683" alt="image" src="https://user-images.githubusercontent.com/4198311/172397906-f80c4ce9-b989-4c8e-b543-8585023f4cfa.png">
