### PR TITLE
Fix include file name

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -376,13 +376,16 @@ fn parse_file_inner(filename: Arc<str>, path: &Path) -> Result<Vec<Record>, Pars
                 .filter_map(Result::ok)
             {
                 let new_filename_str = included_file.as_os_str().to_string_lossy().to_string();
-                let new_filename =
-                    Arc::from(new_filename_str.clone());
+                let new_filename = Arc::from(new_filename_str.clone());
                 let new_path = included_file.as_path();
 
-                records.push(Record::Control(Control::BeginInclude(new_filename_str.clone())));
+                records.push(Record::Control(Control::BeginInclude(
+                    new_filename_str.clone(),
+                )));
                 records.extend(parse_file_inner(new_filename, new_path)?);
-                records.push(Record::Control(Control::EndInclude(new_filename_str.clone())));
+                records.push(Record::Control(Control::EndInclude(
+                    new_filename_str.clone(),
+                )));
             }
         } else {
             records.push(rec);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -375,13 +375,14 @@ fn parse_file_inner(filename: Arc<str>, path: &Path) -> Result<Vec<Record>, Pars
                 .map_err(|e| InvalidIncludeFile(format!("{:?}", e)).at(loc))?
                 .filter_map(Result::ok)
             {
+                let new_filename_str = included_file.as_os_str().to_string_lossy().to_string();
                 let new_filename =
-                    Arc::from(included_file.as_os_str().to_string_lossy().to_string());
+                    Arc::from(new_filename_str.clone());
                 let new_path = included_file.as_path();
 
-                records.push(Record::Control(Control::BeginInclude(filename.clone())));
+                records.push(Record::Control(Control::BeginInclude(new_filename_str.clone())));
                 records.extend(parse_file_inner(new_filename, new_path)?);
-                records.push(Record::Control(Control::EndInclude(filename.clone())));
+                records.push(Record::Control(Control::EndInclude(new_filename_str.clone())));
             }
         } else {
             records.push(rec);


### PR DESCRIPTION
Signed-off-by: Renjie Liu <liurenjie2008@gmail.com>

When `include` contains wildchar, the expaned include statement before:
```
./example/*.slt
./example/*.slt
```

After fixed:
```
./example/a.slt
./example/b.slt
```

