### PR TITLE
feat: add junit support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           command: test
           args: --no-fail-fast --all-features
-      - name: Run all examples
+      - name: Run examples
         run: |
           for example in examples/*.rs
           do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3] - 2022-06-26
+
+### Added
+
+- Add junit support. Use `--junit <filename>` to generate junit xml.
+
+
 ## [0.5.2] - 2022-06-16
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqllogictest"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "Sqllogictest parser and runner."
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["sql", "database", "parser", "cli"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-bin = ["anyhow", "console", "tokio-postgres", "env_logger", "clap", "tokio", "futures"]
+bin = ["anyhow", "console", "tokio-postgres", "env_logger", "clap", "tokio", "futures", "quick-junit"]
 
 [dependencies]
 anyhow = { version = "1", optional = true }
@@ -26,6 +26,7 @@ glob = "0.3"
 humantime = "2"
 itertools = "0.10"
 log = "0.4"
+quick-junit = { version = "0.2", optional = true }
 tempfile = "3"
 thiserror = "1"
 tokio = { version = "1", features = [

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,10 +1,11 @@
 //! Sqllogictest parser.
 
-use crate::ParseErrorKind::InvalidIncludeFile;
 use std::fmt;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
+
+use crate::ParseErrorKind::InvalidIncludeFile;
 
 /// The location in source file.
 #[derive(Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

junit is a generic exchange format of delivering test result. With this integration, sqllogictest users can upload and analyze sqllogictest result with ease.

Also bump a minor version as this doesn't change lib interface.