### PR TITLE
refactor: move diff output into lib

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 pub struct FakeDB;
 
 #[derive(Debug)]
@@ -34,7 +32,6 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let script = std::fs::read_to_string(Path::new("examples/basic.slt")).unwrap();
     let mut tester = sqllogictest::Runner::new(FakeDB);
-    tester.run_script(&script).unwrap();
+    tester.run_file("examples/basic.slt").unwrap();
 }

--- a/examples/condition.rs
+++ b/examples/condition.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 pub struct FakeDB {
     engine_name: &'static str,
 }
@@ -32,10 +30,8 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let script = std::fs::read_to_string(Path::new("examples/condition.slt")).unwrap();
-
     for engine_name in ["risinglight", "otherdb"] {
         let mut tester = sqllogictest::Runner::new(FakeDB { engine_name });
-        tester.run_script(&script).unwrap();
+        tester.run_file("examples/condition.slt").unwrap();
     }
 }

--- a/examples/file_level_sort_mode.rs
+++ b/examples/file_level_sort_mode.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 pub struct FakeDB;
 
 #[derive(Debug)]
@@ -27,7 +25,8 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let script = std::fs::read_to_string(Path::new("examples/file_level_sort_mode.slt")).unwrap();
     let mut tester = sqllogictest::Runner::new(FakeDB);
-    tester.run_script(&script).unwrap();
+    tester
+        .run_file("examples/file_level_sort_mode.slt")
+        .unwrap();
 }

--- a/examples/rowsort.rs
+++ b/examples/rowsort.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 pub struct FakeDB;
 
 #[derive(Debug)]
@@ -27,7 +25,6 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let script = std::fs::read_to_string(Path::new("examples/rowsort.slt")).unwrap();
     let mut tester = sqllogictest::Runner::new(FakeDB);
-    tester.run_script(&script).unwrap();
+    tester.run_file("examples/rowsort.slt").unwrap();
 }

--- a/examples/test_dir_escape.rs
+++ b/examples/test_dir_escape.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 pub struct FakeDB;
 
 #[derive(Debug)]
@@ -25,9 +23,8 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let script = std::fs::read_to_string(Path::new("examples/test_dir_escape.slt")).unwrap();
     let mut tester = sqllogictest::Runner::new(FakeDB);
     // enable `__TEST_DIR__` override
     tester.enable_testdir();
-    tester.run_script(&script).unwrap();
+    tester.run_file("examples/test_dir_escape.slt").unwrap();
 }

--- a/examples/validator.rs
+++ b/examples/validator.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 pub struct FakeDB;
 
 #[derive(Debug)]
@@ -22,9 +20,8 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let script = std::fs::read_to_string(Path::new("examples/validator.slt")).unwrap();
     let mut tester = sqllogictest::Runner::new(FakeDB);
     // Validator will always return true.
     tester.with_validator(|_, _| true);
-    tester.run_script(&script).unwrap();
+    tester.run_file("examples/validator.slt").unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use console::style;
 use futures::StreamExt;
 use itertools::Itertools;
 use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite};
-use sqllogictest::{Control, Record, TestErrorKind};
+use sqllogictest::{Control, Record};
 
 #[derive(Copy, Clone, Debug, PartialEq, ArgEnum)]
 #[must_use]
@@ -395,10 +395,14 @@ async fn run_test_file<T: std::io::Write>(
             }
             _ => {}
         }
-        runner.run_async(record).await.context(format!(
-            "failed to run `{}`",
-            style(filename.to_string_lossy()).bold()
-        ))?;
+        runner
+            .run_async(record)
+            .await
+            .map_err(|e| anyhow!("{:?}", e))
+            .context(format!(
+                "failed to run `{}`",
+                style(filename.to_string_lossy()).bold()
+            ))?;
     }
 
     let duration = begin_times[0].elapsed();

--- a/src/main.rs
+++ b/src/main.rs
@@ -395,26 +395,10 @@ async fn run_test_file<T: std::io::Write>(
             }
             _ => {}
         }
-        runner
-            .run_async(record)
-            .await
-            .map_err(|e| {
-                if let TestErrorKind::QueryResultMismatch {
-                    sql,
-                    expected,
-                    actual,
-                } = e.kind()
-                {
-                    let diff = difference::Changeset::new(&expected, &actual, "\n").to_string();
-                    anyhow!("query result mismatch:\nSQL: {}\nDiff:\n{}", sql, diff)
-                } else {
-                    anyhow!("{:?}", e)
-                }
-            })
-            .context(format!(
-                "failed to run `{}`",
-                style(filename.to_string_lossy()).bold()
-            ))?;
+        runner.run_async(record).await.context(format!(
+            "failed to run `{}`",
+            style(filename.to_string_lossy()).bold()
+        ))?;
     }
 
     let duration = begin_times[0].elapsed();

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -85,27 +85,25 @@ impl TestError {
 /// The error kind for running sqllogictest.
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum TestErrorKind {
-    #[error("statement is expected to fail, but actually succeed:\nSQL: {sql}")]
+    #[error("statement is expected to fail, but actually succeed:\n[SQL] {sql}")]
     StatementOk { sql: String },
-    #[error("statement failed: {err}\nSQL: {sql}")]
+    #[error("statement failed: {err}\n[SQL] {sql}")]
     StatementFail {
         sql: String,
         err: Rc<dyn std::error::Error>,
     },
-    #[error(
-        "statement is expected to affect {expected} rows, but actually {actual}\n\tSQL: {sql}"
-    )]
+    #[error("statement is expected to affect {expected} rows, but actually {actual}\n[SQL] {sql}")]
     StatementResultMismatch {
         sql: String,
         expected: u64,
         actual: String,
     },
-    #[error("query failed: {err}\nSQL: {sql}")]
+    #[error("query failed: {err}\n[SQL] {sql}")]
     QueryFail {
         sql: String,
         err: Rc<dyn std::error::Error>,
     },
-    #[error("query result mismatch:\nSQL: {sql}\nExpected:\n{expected}\nActual:\n{actual}")]
+    #[error("query result mismatch:\n[SQL] {sql}\n[Diff]\n{}", difference::Changeset::new(.expected, .actual, "\n"))]
     QueryResultMismatch {
         sql: String,
         expected: String,


### PR DESCRIPTION
This PR moves the diff output into the `TestErrorKind` struct.