### PR TITLE
feat: add sleep fn to AsyncDB

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -25,8 +25,11 @@ pub trait AsyncDB: Send {
         ""
     }
 
-    /// Sleep for a while.
-    #[doc(hidden)]
+    /// [`Runner`] calls this function to perform sleep.
+    ///
+    /// The default implementation is `std::thread::sleep`, which is universial to any async runtime
+    /// but would block the current thread. If you are running in tokio runtime, you should override
+    /// this by `tokio::time::sleep`.
     async fn sleep(dur: Duration) {
         std::thread::sleep(dur);
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2,6 +2,7 @@
 
 use std::path::Path;
 use std::rc::Rc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use futures_lite::future;
@@ -22,6 +23,12 @@ pub trait AsyncDB: Send {
     /// Engine name of current database.
     fn engine_name(&self) -> &str {
         ""
+    }
+
+    /// Sleep for a while.
+    #[doc(hidden)]
+    async fn sleep(dur: Duration) {
+        std::thread::sleep(dur);
     }
 }
 
@@ -232,7 +239,7 @@ impl<D: AsyncDB> Runner<D> {
                     .at(loc));
                 }
             }
-            Record::Sleep { duration, .. } => std::thread::sleep(duration),
+            Record::Sleep { duration, .. } => D::sleep(duration).await,
             Record::Halt { .. } => {}
             Record::Subtest { .. } => {}
             Record::Include { loc, .. } => {


### PR DESCRIPTION
Signed-off-by: Runji Wang <wangrunji0408@163.com>

This PR adds a function `sleep` to `AsyncDB` trait, so that we can specify how the runner does it.
By default it calls `std::thread::sleep` as previous. We can change it to `tokio::time::sleep` or `madsim::time::sleep` in necessary.
I'm not sure whether it should be a public API so I hide it from rustdoc.