### PR TITLE
support extended query mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bin = ["anyhow", "chrono", "console", "tokio-postgres", "env_logger", "clap", "t
 [dependencies]
 anyhow = { version = "1", optional = true }
 async-trait = "0.1"
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4",optional = true }
 clap = { version = "3", features = ["derive", "env"], optional = true }
 console = { version = "0.15", optional = true }
 difference = "2.0"
@@ -27,7 +27,9 @@ glob = "0.3"
 humantime = "2"
 itertools = "0.10"
 log = "0.4"
+postgres-types = { version = "0.2.3", features = ["derive","with-chrono-0_4"] }
 quick-junit = { version = "0.2", optional = true }
+rust_decimal = { version = "1.7.0", features = [ "tokio-pg" ] }
 tempfile = "3"
 thiserror = "1"
 tokio = { version = "1", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ keywords = ["sql", "database", "parser", "cli"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-bin = ["anyhow", "chrono", "console", "tokio-postgres", "env_logger", "clap", "tokio", "futures", "quick-junit"]
+bin = ["anyhow", "chrono", "console", "tokio-postgres", "env_logger", "clap", "tokio", "futures", "quick-junit", "postgres-types", "rust_decimal"]
 
 [dependencies]
 anyhow = { version = "1", optional = true }
 async-trait = "0.1"
-chrono = { version = "0.4",optional = true }
+chrono = { version = "0.4", optional = true }
 clap = { version = "3", features = ["derive", "env"], optional = true }
 console = { version = "0.15", optional = true }
 difference = "2.0"
@@ -27,9 +27,9 @@ glob = "0.3"
 humantime = "2"
 itertools = "0.10"
 log = "0.4"
-postgres-types = { version = "0.2.3", features = ["derive","with-chrono-0_4"] }
+postgres-types = { version = "0.2.3", features = ["derive","with-chrono-0_4"], optional = true }
 quick-junit = { version = "0.2", optional = true }
-rust_decimal = { version = "1.7.0", features = [ "tokio-pg" ] }
+rust_decimal = { version = "1.7.0", features = [ "tokio-pg" ], optional = true }
 tempfile = "3"
 thiserror = "1"
 tokio = { version = "1", features = [


### PR DESCRIPTION
Support extended query mode.
It's compatible with past versions, extended query mode only takes effect when using the flag  "--extend"

for now, this pr has the following limit:
- we only support most common type in binary format (but not all the type.
- rust-postgres only support one-dimensional array type.

Hence we can run all original e2e test now.