### PR TITLE
refactor: use cargo workspace inheritance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           components: rustfmt, clippy
       - name: Check code format
         uses: actions-rs/cargo@v1
@@ -44,7 +44,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           components: rustfmt, clippy
       - uses: actions-rs/cargo@v1
         name: Compile all targets 🚀

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,10 @@
 [workspace]
 members = ["sqllogictest", "sqllogictest-bin", "examples/*", "tests"]
+
+[workspace.package]
+version = "0.6.4"
+edition = "2021"
+homepage = "https://github.com/risinglightdb/sqllogictest-rs"
+keywords = ["sql", "database", "parser", "cli"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/risinglightdb/sqllogictest-rs"

--- a/sqllogictest-bin/Cargo.toml
+++ b/sqllogictest-bin/Cargo.toml
@@ -1,15 +1,13 @@
 [package]
 name = "sqllogictest-bin"
-version = "0.6.4"
-edition = "2021"
-homepage = "https://github.com/risinglightdb/sqllogictest-rs"
-keywords = ["sql", "database", "parser", "cli"]
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/risinglightdb/sqllogictest-rs"
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 description = "Sqllogictest CLI."
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 anyhow = { version = "1" }
 async-trait = "0.1"
@@ -31,5 +29,11 @@ rust_decimal = { version = "1.7.0", features = ["tokio-pg"] }
 sqllogictest = { path = "../sqllogictest", version = "0.6" }
 tempfile = "3"
 thiserror = "1"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "fs"] }
+tokio = { version = "1", features = [
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "macros",
+    "fs",
+] }
 tokio-postgres = { version = "0.7" }

--- a/sqllogictest/Cargo.toml
+++ b/sqllogictest/Cargo.toml
@@ -1,15 +1,13 @@
 [package]
 name = "sqllogictest"
-version = "0.6.4"
-edition = "2021"
-homepage = "https://github.com/risinglightdb/sqllogictest-rs"
-keywords = ["sql", "database", "parser", "cli"]
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/risinglightdb/sqllogictest-rs"
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 description = "Sqllogictest parser and runner."
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 async-trait = "0.1"
 difference = "2.0"


### PR DESCRIPTION
Wait for rust 1.64 on 9.22 🥸