### PR TITLE
refactor: use Vec<Vec<String>> as query results & fix hash-threshold  

### DIFF
--- a/examples/basic/examples/basic.rs
+++ b/examples/basic/examples/basic.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use sqllogictest::{ColumnType, DBOutput};
+
 pub struct FakeDB;
 
 #[derive(Debug)]
@@ -16,18 +18,25 @@ impl std::error::Error for FakeDBError {}
 impl sqllogictest::DB for FakeDB {
     type Error = FakeDBError;
 
-    fn run(&mut self, sql: &str) -> Result<String, FakeDBError> {
+    fn run(&mut self, sql: &str) -> Result<DBOutput, FakeDBError> {
         if sql == "select * from example_basic" {
-            return Ok("Alice\nBob\nEve".into());
+            return Ok(DBOutput::Rows {
+                types: vec![ColumnType::Text],
+                rows: vec![
+                    vec!["Alice".to_string()],
+                    vec!["Bob".to_string()],
+                    vec!["Eve".to_string()],
+                ],
+            });
         }
         if sql.starts_with("create") {
-            return Ok("".into());
+            return Ok(DBOutput::StatementComplete(0));
         }
         if sql.starts_with("insert") {
-            return Ok("".into());
+            return Ok(DBOutput::StatementComplete(0));
         }
         if sql.starts_with("drop") {
-            return Ok("".into());
+            return Ok(DBOutput::StatementComplete(0));
         }
         Err(FakeDBError)
     }

--- a/examples/condition/examples/condition.rs
+++ b/examples/condition/examples/condition.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use sqllogictest::{ColumnType, DBOutput};
+
 pub struct FakeDB {
     engine_name: &'static str,
 }
@@ -18,9 +20,16 @@ impl std::error::Error for FakeDBError {}
 impl sqllogictest::DB for FakeDB {
     type Error = FakeDBError;
 
-    fn run(&mut self, sql: &str) -> Result<String, FakeDBError> {
+    fn run(&mut self, sql: &str) -> Result<DBOutput, FakeDBError> {
         if sql.contains(self.engine_name) {
-            Ok("Alice\nBob\nEve".into())
+            Ok(DBOutput::Rows {
+                types: vec![ColumnType::Text],
+                rows: vec![
+                    vec!["Alice".to_string()],
+                    vec!["Bob".to_string()],
+                    vec!["Eve".to_string()],
+                ],
+            })
         } else {
             Err(FakeDBError)
         }

--- a/examples/file_level_sort_mode/examples/file_level_sort_mode.rs
+++ b/examples/file_level_sort_mode/examples/file_level_sort_mode.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use sqllogictest::{ColumnType, DBOutput};
+
 pub struct FakeDB;
 
 #[derive(Debug)]
@@ -16,11 +18,22 @@ impl std::error::Error for FakeDBError {}
 impl sqllogictest::DB for FakeDB {
     type Error = FakeDBError;
 
-    fn run(&mut self, sql: &str) -> Result<String, FakeDBError> {
+    fn run(&mut self, sql: &str) -> Result<DBOutput, FakeDBError> {
         if sql == "select * from example_file_level_sort_mode" {
             // Even if the order is not the same as `slt` file, sqllogictest will sort them before
             // comparing.
-            return Ok("1 10 2333\n2 20 2333\n10 100 2333".into());
+            return Ok(DBOutput::Rows {
+                types: vec![
+                    ColumnType::Integer,
+                    ColumnType::Integer,
+                    ColumnType::Integer,
+                ],
+                rows: vec![
+                    vec!["1".to_string(), "10".to_string(), "2333".to_string()],
+                    vec!["2".to_string(), "20".to_string(), "2333".to_string()],
+                    vec!["10".to_string(), "100".to_string(), "2333".to_string()],
+                ],
+            });
         }
         unimplemented!("unsupported SQL: {}", sql);
     }

--- a/examples/include/examples/include.rs
+++ b/examples/include/examples/include.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use sqllogictest::{ColumnType, DBOutput};
+
 pub struct FakeDB;
 
 #[derive(Debug)]
@@ -16,18 +18,25 @@ impl std::error::Error for FakeDBError {}
 impl sqllogictest::DB for FakeDB {
     type Error = FakeDBError;
 
-    fn run(&mut self, sql: &str) -> Result<String, FakeDBError> {
+    fn run(&mut self, sql: &str) -> Result<DBOutput, FakeDBError> {
         if sql == "select * from example_basic" {
-            return Ok("Alice\nBob\nEve".into());
+            return Ok(DBOutput::Rows {
+                types: vec![ColumnType::Text],
+                rows: vec![
+                    vec!["Alice".to_string()],
+                    vec!["Bob".to_string()],
+                    vec!["Eve".to_string()],
+                ],
+            });
         }
         if sql.starts_with("create") {
-            return Ok("".into());
+            return Ok(DBOutput::StatementComplete(0));
         }
         if sql.starts_with("insert") {
-            return Ok("".into());
+            return Ok(DBOutput::StatementComplete(0));
         }
         if sql.starts_with("drop") {
-            return Ok("".into());
+            return Ok(DBOutput::StatementComplete(0));
         }
         unimplemented!("unsupported SQL: {}", sql);
     }

--- a/examples/rowsort/examples/rowsort.rs
+++ b/examples/rowsort/examples/rowsort.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use sqllogictest::{ColumnType, DBOutput};
+
 pub struct FakeDB;
 
 #[derive(Debug)]
@@ -16,11 +18,22 @@ impl std::error::Error for FakeDBError {}
 impl sqllogictest::DB for FakeDB {
     type Error = FakeDBError;
 
-    fn run(&mut self, sql: &str) -> Result<String, FakeDBError> {
+    fn run(&mut self, sql: &str) -> Result<DBOutput, FakeDBError> {
         if sql == "select * from example_rowsort" {
             // Even if the order is not the same as `slt` file, sqllogictest will sort them before
             // comparing.
-            return Ok("1 10 2333\n2 20 2333\n10 100 2333".into());
+            return Ok(DBOutput::Rows {
+                types: vec![
+                    ColumnType::Integer,
+                    ColumnType::Integer,
+                    ColumnType::Integer,
+                ],
+                rows: vec![
+                    vec!["1".to_string(), "10".to_string(), "2333".to_string()],
+                    vec!["2".to_string(), "20".to_string(), "2333".to_string()],
+                    vec!["10".to_string(), "100".to_string(), "2333".to_string()],
+                ],
+            });
         }
         unimplemented!("unsupported SQL: {}", sql);
     }

--- a/examples/test_dir_escape/examples/test_dir_escape.rs
+++ b/examples/test_dir_escape/examples/test_dir_escape.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use sqllogictest::DBOutput;
+
 pub struct FakeDB;
 
 #[derive(Debug)]
@@ -16,11 +18,11 @@ impl std::error::Error for FakeDBError {}
 impl sqllogictest::DB for FakeDB {
     type Error = FakeDBError;
 
-    fn run(&mut self, sql: &str) -> Result<String, FakeDBError> {
+    fn run(&mut self, sql: &str) -> Result<DBOutput, FakeDBError> {
         // Output will be: sqllogictests yields copy test to '/tmp/.tmp6xSyMa/test.csv';
         println!("sqllogictests yields {}", sql);
         assert!(!sql.contains("__TEST_DIR__"));
-        Ok("".into())
+        Ok(DBOutput::StatementComplete(0))
     }
 }
 

--- a/examples/validator/examples/validator.rs
+++ b/examples/validator/examples/validator.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use sqllogictest::{ColumnType, DBOutput};
+
 pub struct FakeDB;
 
 #[derive(Debug)]
@@ -16,8 +18,11 @@ impl std::error::Error for FakeDBError {}
 impl sqllogictest::DB for FakeDB {
     type Error = FakeDBError;
 
-    fn run(&mut self, _sql: &str) -> Result<String, FakeDBError> {
-        Ok("Hello, world!".to_string())
+    fn run(&mut self, _sql: &str) -> Result<DBOutput, FakeDBError> {
+        Ok(DBOutput::Rows {
+            types: vec![ColumnType::Text],
+            rows: vec![vec!["Hello, world!".to_string()]],
+        })
     }
 }
 

--- a/sqllogictest-bin/src/engines/mod.rs
+++ b/sqllogictest-bin/src/engines/mod.rs
@@ -8,7 +8,7 @@ mod external;
 
 use async_trait::async_trait;
 use postgres_extended::PostgresExtended;
-use sqllogictest::AsyncDB;
+use sqllogictest::{AsyncDB, DBOutput};
 
 use self::external::ExternalDriver;
 use super::{DBConfig, Result};
@@ -70,7 +70,7 @@ impl std::error::Error for AnyhowError {
 }
 
 impl Engines {
-    async fn run(&mut self, sql: &str) -> Result<String, anyhow::Error> {
+    async fn run(&mut self, sql: &str) -> Result<DBOutput, anyhow::Error> {
         Ok(match self {
             Engines::Postgres(e) => e.run(sql).await?,
             Engines::PostgresExtended(e) => e.run(sql).await?,
@@ -83,7 +83,7 @@ impl Engines {
 impl AsyncDB for Engines {
     type Error = AnyhowError;
 
-    async fn run(&mut self, sql: &str) -> Result<String, Self::Error> {
+    async fn run(&mut self, sql: &str) -> Result<DBOutput, Self::Error> {
         self.run(sql).await.map_err(AnyhowError)
     }
 }

--- a/sqllogictest-bin/src/engines/postgres.rs
+++ b/sqllogictest-bin/src/engines/postgres.rs
@@ -53,7 +53,7 @@ impl sqllogictest::AsyncDB for Postgres {
         let mut output = vec![];
 
         let is_query_sql = {
-            let lower_sql = sql.to_ascii_lowercase();
+            let lower_sql = sql.trim_start().to_ascii_lowercase();
             lower_sql.starts_with("select")
                 || lower_sql.starts_with("values")
                 || lower_sql.starts_with("show")

--- a/sqllogictest-bin/src/engines/postgres_extended.rs
+++ b/sqllogictest-bin/src/engines/postgres_extended.rs
@@ -226,7 +226,7 @@ impl sqllogictest::AsyncDB for PostgresExtended {
         let mut output = vec![];
 
         let is_query_sql = {
-            let lower_sql = sql.to_ascii_lowercase();
+            let lower_sql = sql.trim_start().to_ascii_lowercase();
             lower_sql.starts_with("select")
                 || lower_sql.starts_with("values")
                 || lower_sql.starts_with("show")

--- a/sqllogictest-bin/src/engines/postgres_extended.rs
+++ b/sqllogictest-bin/src/engines/postgres_extended.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -6,6 +7,7 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime};
 use pg_interval::Interval;
 use postgres_types::Type;
 use rust_decimal::Decimal;
+use sqllogictest::{ColumnType, DBOutput};
 use tokio::task::JoinHandle;
 
 use crate::{DBConfig, Result};
@@ -49,61 +51,66 @@ impl Drop for PostgresExtended {
 }
 
 macro_rules! array_process {
-    ($row:ident, $output:ident, $idx:ident, $t:ty) => {
+    ($row:ident, $row_vec:ident, $idx:ident, $t:ty) => {
         let value: Option<Vec<Option<$t>>> = $row.get($idx);
         match value {
             Some(value) => {
-                write!($output, "{{").unwrap();
+                let mut output = String::new();
+                write!(output, "{{").unwrap();
                 for (i, v) in value.iter().enumerate() {
                     match v {
                         Some(v) => {
-                            write!($output, "{}", v).unwrap();
+                            write!(output, "{}", v).unwrap();
                         }
                         None => {
-                            write!($output, "NULL").unwrap();
+                            write!(output, "NULL").unwrap();
                         }
                     }
                     if i < value.len() - 1 {
-                        write!($output, ",").unwrap();
+                        write!(output, ",").unwrap();
                     }
                 }
-                write!($output, "}}").unwrap();
+                write!(output, "}}").unwrap();
+                $row_vec.push(output);
             }
             None => {
-                write!($output, "NULL").unwrap();
+                $row_vec.push("NULL".to_string());
             }
         }
     };
-    ($row:ident, $output:ident, $idx:ident, $t:ty, $convert:ident) => {
+    ($row:ident, $row_vec:ident, $idx:ident, $t:ty, $convert:ident) => {
         let value: Option<Vec<Option<$t>>> = $row.get($idx);
         match value {
             Some(value) => {
-                write!($output, "{{").unwrap();
+                let mut output = String::new();
+                write!(output, "{{").unwrap();
                 for (i, v) in value.iter().enumerate() {
                     match v {
                         Some(v) => {
-                            write!($output, "{}", $convert(v)).unwrap();
+                            write!(output, "{}", $convert(v)).unwrap();
                         }
                         None => {
-                            write!($output, "NULL").unwrap();
+                            write!(output, "NULL").unwrap();
                         }
                     }
                     if i < value.len() - 1 {
-                        write!($output, ",").unwrap();
+                        write!(output, ",").unwrap();
                     }
                 }
-                write!($output, "}}").unwrap();
+                write!(output, "}}").unwrap();
+                $row_vec.push(output);
             }
             None => {
-                write!($output, "NULL").unwrap();
+                $row_vec.push("NULL".to_string());
             }
         }
     };
-    ($self:ident, $row:ident, $output:ident, $idx:ident, $t:ty, $ty_name:expr) => {
+    ($self:ident, $row:ident, $row_vec:ident, $idx:ident, $t:ty, $ty_name:expr) => {
         let value: Option<Vec<Option<$t>>> = $row.get($idx);
         match value {
             Some(value) => {
-                write!($output, "{{").unwrap();
+                let mut output = String::new();
+                write!(output, "{{").unwrap();
                 for (i, v) in value.iter().enumerate() {
                     match v {
                         Some(v) => {
@@ -111,49 +118,50 @@ macro_rules! array_process {
                             let tmp_rows = $self.client.query(&sql, &[&v]).await.unwrap();
                             let value: &str = tmp_rows.get(0).unwrap().get(0);
                             assert!(value.len() > 0);
-                            write!($output, "{}", value).unwrap();
+                            write!(output, "{}", value).unwrap();
                         }
                         None => {
-                            write!($output, "NULL").unwrap();
+                            write!(output, "NULL").unwrap();
                         }
                     }
                     if i < value.len() - 1 {
-                        write!($output, ",").unwrap();
+                        write!(output, ",").unwrap();
                     }
                 }
-                write!($output, "}}").unwrap();
+                write!(output, "}}").unwrap();
+                $row_vec.push(output);
             }
             None => {
-                write!($output, "NULL").unwrap();
+                $row_vec.push("NULL".to_string());
             }
         }
     };
 }
 
 macro_rules! single_process {
-    ($row:ident, $output:ident, $idx:ident, $t:ty) => {
+    ($row:ident, $row_vec:ident, $idx:ident, $t:ty) => {
         let value: Option<$t> = $row.get($idx);
         match value {
             Some(value) => {
-                write!($output, "{}", value).unwrap();
+                $row_vec.push(value.to_string());
             }
             None => {
-                write!($output, "NULL").unwrap();
+                $row_vec.push("NULL".to_string());
             }
         }
     };
-    ($row:ident, $output:ident, $idx:ident, $t:ty, $convert:ident) => {
+    ($row:ident, $row_vec:ident, $idx:ident, $t:ty, $convert:ident) => {
         let value: Option<$t> = $row.get($idx);
         match value {
             Some(value) => {
-                write!($output, "{}", $convert(&value)).unwrap();
+                $row_vec.push($convert(&value).to_string());
             }
             None => {
-                write!($output, "NULL").unwrap();
+                $row_vec.push("NULL".to_string());
             }
         }
     };
-    ($self:ident, $row:ident, $output:ident, $idx:ident, $t:ty, $ty_name:expr) => {
+    ($self:ident, $row:ident, $row_vec:ident, $idx:ident, $t:ty, $ty_name:expr) => {
         let value: Option<$t> = $row.get($idx);
         match value {
             Some(value) => {
@@ -161,10 +169,10 @@ macro_rules! single_process {
                 let tmp_rows = $self.client.query(&sql, &[&value]).await.unwrap();
                 let value: &str = tmp_rows.get(0).unwrap().get(0);
                 assert!(value.len() > 0);
-                write!($output, "{}", value).unwrap();
+                $row_vec.push(value.to_string());
             }
             None => {
-                write!($output, "NULL").unwrap();
+                $row_vec.push("NULL".to_string());
             }
         }
     };
@@ -214,10 +222,8 @@ fn float8_to_str(value: &f64) -> String {
 impl sqllogictest::AsyncDB for PostgresExtended {
     type Error = tokio_postgres::error::Error;
 
-    async fn run(&mut self, sql: &str) -> Result<String, Self::Error> {
-        use std::fmt::Write;
-
-        let mut output = String::new();
+    async fn run(&mut self, sql: &str) -> Result<DBOutput, Self::Error> {
+        let mut output = vec![];
 
         let is_query_sql = {
             let lower_sql = sql.to_ascii_lowercase();
@@ -227,117 +233,121 @@ impl sqllogictest::AsyncDB for PostgresExtended {
                 || lower_sql.starts_with("with")
                 || lower_sql.starts_with("describe")
         };
-        if is_query_sql {
-            let rows = self.client.query(sql, &[]).await?;
-            for row in rows {
-                for (idx, column) in row.columns().iter().enumerate() {
-                    if idx != 0 {
-                        write!(output, " ").unwrap();
+        if !is_query_sql {
+            self.client.execute(sql, &[]).await?;
+            return Ok(DBOutput::StatementComplete(0));
+        }
+
+        let rows = self.client.query(sql, &[]).await?;
+        for row in rows {
+            let mut row_vec = vec![];
+
+            for (idx, column) in row.columns().iter().enumerate() {
+                match column.type_().clone() {
+                    Type::INT2 => {
+                        single_process!(row, row_vec, idx, i16);
                     }
-                    match column.type_().clone() {
-                        Type::INT2 => {
-                            single_process!(row, output, idx, i16);
-                        }
-                        Type::INT4 => {
-                            single_process!(row, output, idx, i32);
-                        }
-                        Type::INT8 => {
-                            single_process!(row, output, idx, i64);
-                        }
-                        Type::NUMERIC => {
-                            single_process!(row, output, idx, Decimal);
-                        }
-                        Type::DATE => {
-                            single_process!(row, output, idx, NaiveDate);
-                        }
-                        Type::TIME => {
-                            single_process!(row, output, idx, NaiveTime);
-                        }
-                        Type::TIMESTAMP => {
-                            single_process!(row, output, idx, NaiveDateTime);
-                        }
-                        Type::BOOL => {
-                            single_process!(row, output, idx, bool, bool_to_str);
-                        }
-                        Type::INT2_ARRAY => {
-                            array_process!(row, output, idx, i16);
-                        }
-                        Type::INT4_ARRAY => {
-                            array_process!(row, output, idx, i32);
-                        }
-                        Type::INT8_ARRAY => {
-                            array_process!(row, output, idx, i64);
-                        }
-                        Type::BOOL_ARRAY => {
-                            array_process!(row, output, idx, bool, bool_to_str);
-                        }
-                        Type::FLOAT4_ARRAY => {
-                            array_process!(row, output, idx, f32, float4_to_str);
-                        }
-                        Type::FLOAT8_ARRAY => {
-                            array_process!(row, output, idx, f64, float8_to_str);
-                        }
-                        Type::NUMERIC_ARRAY => {
-                            array_process!(row, output, idx, Decimal);
-                        }
-                        Type::DATE_ARRAY => {
-                            array_process!(row, output, idx, NaiveDate);
-                        }
-                        Type::TIME_ARRAY => {
-                            array_process!(row, output, idx, NaiveTime);
-                        }
-                        Type::TIMESTAMP_ARRAY => {
-                            array_process!(row, output, idx, NaiveDateTime);
-                        }
-                        Type::VARCHAR_ARRAY | Type::TEXT_ARRAY => {
-                            array_process!(row, output, idx, String, varchar_to_str);
-                        }
-                        Type::VARCHAR | Type::TEXT => {
-                            single_process!(row, output, idx, String, varchar_to_str);
-                        }
-                        Type::FLOAT4 => {
-                            single_process!(row, output, idx, f32, float4_to_str);
-                        }
-                        Type::FLOAT8 => {
-                            single_process!(row, output, idx, f64, float8_to_str);
-                        }
-                        Type::INTERVAL => {
-                            single_process!(self, row, output, idx, Interval, INTERVAL);
-                        }
-                        Type::TIMESTAMPTZ => {
-                            single_process!(
-                                self,
-                                row,
-                                output,
-                                idx,
-                                DateTime<chrono::Utc>,
-                                TIMESTAMPTZ
-                            );
-                        }
-                        Type::INTERVAL_ARRAY => {
-                            array_process!(self, row, output, idx, Interval, INTERVAL);
-                        }
-                        Type::TIMESTAMPTZ_ARRAY => {
-                            array_process!(
-                                self,
-                                row,
-                                output,
-                                idx,
-                                DateTime<chrono::Utc>,
-                                TIMESTAMPTZ
-                            );
-                        }
-                        _ => {
-                            todo!("Don't support {} type now.", column.type_().name())
-                        }
+                    Type::INT4 => {
+                        single_process!(row, row_vec, idx, i32);
+                    }
+                    Type::INT8 => {
+                        single_process!(row, row_vec, idx, i64);
+                    }
+                    Type::NUMERIC => {
+                        single_process!(row, row_vec, idx, Decimal);
+                    }
+                    Type::DATE => {
+                        single_process!(row, row_vec, idx, NaiveDate);
+                    }
+                    Type::TIME => {
+                        single_process!(row, row_vec, idx, NaiveTime);
+                    }
+                    Type::TIMESTAMP => {
+                        single_process!(row, row_vec, idx, NaiveDateTime);
+                    }
+                    Type::BOOL => {
+                        single_process!(row, row_vec, idx, bool, bool_to_str);
+                    }
+                    Type::INT2_ARRAY => {
+                        array_process!(row, row_vec, idx, i16);
+                    }
+                    Type::INT4_ARRAY => {
+                        array_process!(row, row_vec, idx, i32);
+                    }
+                    Type::INT8_ARRAY => {
+                        array_process!(row, row_vec, idx, i64);
+                    }
+                    Type::BOOL_ARRAY => {
+                        array_process!(row, row_vec, idx, bool, bool_to_str);
+                    }
+                    Type::FLOAT4_ARRAY => {
+                        array_process!(row, row_vec, idx, f32, float4_to_str);
+                    }
+                    Type::FLOAT8_ARRAY => {
+                        array_process!(row, row_vec, idx, f64, float8_to_str);
+                    }
+                    Type::NUMERIC_ARRAY => {
+                        array_process!(row, row_vec, idx, Decimal);
+                    }
+                    Type::DATE_ARRAY => {
+                        array_process!(row, row_vec, idx, NaiveDate);
+                    }
+                    Type::TIME_ARRAY => {
+                        array_process!(row, row_vec, idx, NaiveTime);
+                    }
+                    Type::TIMESTAMP_ARRAY => {
+                        array_process!(row, row_vec, idx, NaiveDateTime);
+                    }
+                    Type::VARCHAR_ARRAY | Type::TEXT_ARRAY => {
+                        array_process!(row, row_vec, idx, String, varchar_to_str);
+                    }
+                    Type::VARCHAR | Type::TEXT => {
+                        single_process!(row, row_vec, idx, String, varchar_to_str);
+                    }
+                    Type::FLOAT4 => {
+                        single_process!(row, row_vec, idx, f32, float4_to_str);
+                    }
+                    Type::FLOAT8 => {
+                        single_process!(row, row_vec, idx, f64, float8_to_str);
+                    }
+                    Type::INTERVAL => {
+                        single_process!(self, row, row_vec, idx, Interval, INTERVAL);
+                    }
+                    Type::TIMESTAMPTZ => {
+                        single_process!(
+                            self,
+                            row,
+                            row_vec,
+                            idx,
+                            DateTime<chrono::Utc>,
+                            TIMESTAMPTZ
+                        );
+                    }
+                    Type::INTERVAL_ARRAY => {
+                        array_process!(self, row, row_vec, idx, Interval, INTERVAL);
+                    }
+                    Type::TIMESTAMPTZ_ARRAY => {
+                        array_process!(self, row, row_vec, idx, DateTime<chrono::Utc>, TIMESTAMPTZ);
+                    }
+                    _ => {
+                        todo!("Don't support {} type now.", column.type_().name())
                     }
                 }
-                writeln!(output).unwrap();
             }
-        } else {
-            self.client.execute(sql, &[]).await?;
+            output.push(row_vec);
         }
-        Ok(output)
+
+        if output.is_empty() {
+            Ok(DBOutput::Rows {
+                types: vec![],
+                rows: vec![],
+            })
+        } else {
+            Ok(DBOutput::Rows {
+                types: vec![ColumnType::Any; output[0].len()],
+                rows: output,
+            })
+        }
     }
 
     fn engine_name(&self) -> &str {

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -492,7 +492,7 @@ impl<D: AsyncDB> Runner<D> {
                 loc,
                 sql,
                 expected_error,
-                mut expected_results,
+                expected_results,
                 sort_mode,
                 type_string,
 
@@ -566,7 +566,6 @@ impl<D: AsyncDB> Runner<D> {
                     None | Some(SortMode::NoSort) => {}
                     Some(SortMode::RowSort) => {
                         output.sort_unstable();
-                        expected_results.sort_unstable();
                     }
                     Some(SortMode::ValueSort) => todo!("value sort"),
                 };

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -537,7 +537,7 @@ impl<D: AsyncDB> Runner<D> {
                         return Err(TestErrorKind::QueryResultMismatch {
                             sql,
                             expected: expected_results.join("\n"),
-                            actual: format!("statement complete"),
+                            actual: "statement complete".to_string(),
                         }
                         .at(loc))
                     }
@@ -764,6 +764,7 @@ impl<D: AsyncDB> Runner<D> {
 }
 
 /// Trim and replace multiple whitespaces with one.
+#[allow(clippy::ptr_arg)]
 fn normalize_string(s: &String) -> String {
     s.trim().split_ascii_whitespace().join(" ")
 }

--- a/tests/harness.rs
+++ b/tests/harness.rs
@@ -1,3 +1,5 @@
+use sqllogictest::{ColumnType, DBOutput};
+
 sqllogictest::harness!(FakeDB::new, "slt/**/*.slt");
 
 pub struct FakeDB;
@@ -22,7 +24,10 @@ impl std::error::Error for FakeDBError {}
 impl sqllogictest::DB for FakeDB {
     type Error = FakeDBError;
 
-    fn run(&mut self, _sql: &str) -> Result<String, FakeDBError> {
-        Ok("I'm fake.".into())
+    fn run(&mut self, _sql: &str) -> Result<DBOutput, FakeDBError> {
+        Ok(DBOutput::Rows {
+            types: vec![ColumnType::Text],
+            rows: vec![vec!["I'm fake.".to_string()]],
+        })
     }
 }

--- a/tests/slt/a.slt
+++ b/tests/slt/a.slt
@@ -1,4 +1,4 @@
-query I
+query T
 hi
 ----
 I'm fake.

--- a/tests/slt/b/b.slt
+++ b/tests/slt/b/b.slt
@@ -1,4 +1,4 @@
-query I
+query T
 hello
 ----
 I'm fake.


### PR DESCRIPTION
- Breaking change to `DB` trait
- fix https://github.com/risinglightdb/sqllogictest-rs/issues/107
- fix https://github.com/risinglightdb/sqllogictest-rs/issues/103
- https://github.com/risinglightdb/sqllogictest-rs/issues/36 is now possible, but I didn't enable it yet. I'd like to implement https://github.com/risinglightdb/sqllogictest-rs/issues/43 first so that we can update painlessly.
- Breaking change: only sort actual results now. We need to sort before compute hash. And sorting `Vec<Vec<String>>` is different from sorting rows `Vec<String>`. Note that because of this, risingwave cannot use this version yet.. So we quite need #43