### PR TITLE
feat: support generate & format test files

### DIFF
--- a/sqllogictest-bin/src/engines/postgres.rs
+++ b/sqllogictest-bin/src/engines/postgres.rs
@@ -98,8 +98,9 @@ impl sqllogictest::AsyncDB for Postgres {
         }
 
         if output.is_empty() {
+            let stmt = self.client.prepare(sql).await?;
             Ok(DBOutput::Rows {
-                types: vec![],
+                types: vec![ColumnType::Any; stmt.columns().len()],
                 rows: vec![],
             })
         } else {

--- a/sqllogictest-bin/src/engines/postgres_extended.rs
+++ b/sqllogictest-bin/src/engines/postgres_extended.rs
@@ -338,8 +338,9 @@ impl sqllogictest::AsyncDB for PostgresExtended {
         }
 
         if output.is_empty() {
+            let stmt = self.client.prepare(sql).await?;
             Ok(DBOutput::Rows {
-                types: vec![],
+                types: vec![ColumnType::Any; stmt.columns().len()],
                 rows: vec![],
             })
         } else {

--- a/sqllogictest-bin/src/lib.rs
+++ b/sqllogictest-bin/src/lib.rs
@@ -693,6 +693,7 @@ async fn update_record<D: AsyncDB>(
                 }
             };
 
+            // FIXME: use output's types instead of orignal query's types
             write!(
                 outfile,
                 "query {}",

--- a/sqllogictest-bin/src/lib.rs
+++ b/sqllogictest-bin/src/lib.rs
@@ -713,7 +713,7 @@ async fn update_record<D: AsyncDB>(
             }
 
             let normalized_rows = rows
-                .into_iter()
+                .iter()
                 .map(|strs| strs.iter().map(normalize_string).join(" "))
                 .collect_vec();
 
@@ -727,8 +727,8 @@ async fn update_record<D: AsyncDB>(
                     writeln!(outfile, "{}", result)?;
                 }
             } else {
-                for result in normalized_rows {
-                    writeln!(outfile, "{}", result)?;
+                for result in rows {
+                    writeln!(outfile, "{}", result.iter().format("\t"))?;
                 }
             };
         }

--- a/sqllogictest-bin/src/lib.rs
+++ b/sqllogictest-bin/src/lib.rs
@@ -637,6 +637,29 @@ async fn update_record<D: AsyncDB>(
             writeln!(outfile)?;
         }
         (
+            Record::Statement { sql, .. },
+            RecordOutput::Query {
+                types,
+                rows,
+                error: None,
+            },
+        ) => {
+            writeln!(
+                outfile,
+                "query {}",
+                types.iter().map(|c| format!("{c}")).join("")
+            )?;
+            writeln!(outfile, "{}", sql)?;
+            writeln!(outfile, "----")?;
+            for result in rows {
+                writeln!(outfile, "{}", result.iter().format("\t"))?;
+            }
+        }
+        (Record::Query { sql, .. }, RecordOutput::Statement { error: None, .. }) => {
+            writeln!(outfile, "statement ok")?;
+            writeln!(outfile, "{}", sql)?;
+        }
+        (
             Record::Statement {
                 loc: _,
                 conditions: _,

--- a/sqllogictest/src/parser.rs
+++ b/sqllogictest/src/parser.rs
@@ -179,7 +179,7 @@ impl Record {
                 sql,
                 expected_results,
             } => {
-                write!(w, "query",)?;
+                write!(w, "query")?;
                 if let Some(err) = expected_error {
                     writeln!(w, " error {}", err)?;
                     return write!(w, "{}", sql);
@@ -608,6 +608,6 @@ mod tests {
     #[test]
     fn test_include_glob() {
         let records = parse_file("../examples/include/include_1.slt").unwrap();
-        assert_eq!(12, records.len());
+        assert_eq!(14, records.len());
     }
 }

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -24,6 +24,7 @@ pub enum ColumnType {
     FloatingPoint,
     /// Do not check the type of the column.
     Any,
+    Unknown(char),
 }
 
 impl Display for ColumnType {
@@ -33,6 +34,7 @@ impl Display for ColumnType {
             ColumnType::Integer => write!(f, "I"),
             ColumnType::FloatingPoint => write!(f, "R"),
             ColumnType::Any => write!(f, "?"),
+            ColumnType::Unknown(c) => write!(f, "{}", c),
         }
     }
 }
@@ -48,7 +50,7 @@ impl TryFrom<char> for ColumnType {
             '?' => Ok(Self::Any),
             // FIXME:
             // _ => Err(ParseErrorKind::InvalidType(c)),
-            _ => Ok(Self::Any),
+            _ => Ok(Self::Unknown(c)),
         }
     }
 }


### PR DESCRIPTION
- add CLI option `--override`, and `--format`
- type string and column number not checked yet (https://github.com/risinglightdb/sqllogictest-rs/issues/36), but it would be easy. We need to update the engines first.
- breaking changes to `Record` and parser
  - retain `Include` record when linking its content
  - keep parsing after `Halt`
  - move `Begin/EndInclude` to `Injected`
- breaking change: remove `Hook`

sample run: https://github.com/risingwavelabs/risingwave/pull/6776

close https://github.com/risinglightdb/sqllogictest-rs/issues/43
close https://github.com/risinglightdb/sqllogictest-rs/pull/90