### PR TITLE
release: bump to 0.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,5 @@
 on:
   push:
-    branches:
-      - release
     tags:
       - "v*"
 
@@ -26,22 +24,10 @@ jobs:
           args: --workspace --release
       - name: create tar
         run: tar -cvzf sqllogictest-linux-amd64.tar.gz -C target/release sqllogictest
-      - uses: actions/create-release@latest
-        id: create_release
+      - name: release
+        uses: anton-yurchenko/git-release@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NAME: Release ${{ github.ref }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: ${{ github.event.head_commit.message }}
-          draft: false
-          prerelease: true
-      - name: upload release (tar)
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: sqllogictest-linux-amd64.tar.gz
-          asset_name: sqllogictest-linux-amd64.tar.gz
-          asset_content_type: application/tar+gzip
+          args: sqllogictest-linux-amd64.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,30 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.0] - 2022-12-07
+
+- Improve the format and color handling for errors.
+- Support `hash-threshold`.
+- Fix `statement count <n>` for postgres engines.
+- **Breaking change**: use `Vec<Vec<String>>` instead of `String` as the query results by `DB`. This allows the runner to verify the results more precisely.
+  + For `rowsort`, runner will only sort actual results now, which means the result in the test cases should be sorted.
+- **Breaking change**: `Hook` is removed.
+- **Breaking change**: `Record` and parser's behavior are tweaked:
+  + retain `Include` record when linking its content
+  + keep parsing after `Halt`
+  + move `Begin/EndInclude` to `Injected`
+- Added CLI options `--override` and `--format`, which can override the test files with the actual output of the database, or reformat the test files.
+
 ## [0.8.0] - 2022-11-22
 
 - Support checking error message using `statement error <regex>` and `query error <regex>` syntax.
-  - Breaking change: `Record::Statement`, `Record::Query` and `TestErrorKind` are changed accordingly.
+  - **Breaking change**: `Record::Statement`,  `Record::Query` and `TestErrorKind` are changed accordingly.
 
 ## [0.7.1] - 2022-11-15
 
@@ -60,7 +75,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add junit support. Use `--junit <filename>` to generate junit xml.
-
 
 ## [0.5.2] - 2022-06-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["sqllogictest", "sqllogictest-bin", "examples/*", "tests"]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 homepage = "https://github.com/risinglightdb/sqllogictest-rs"
 keywords = ["sql", "database", "parser", "cli"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add the following lines to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-sqllogictest = "0.8"
+sqllogictest = "0.9"
 ```
 
 Implement `DB` trait for your database structure:

--- a/sqllogictest-bin/Cargo.toml
+++ b/sqllogictest-bin/Cargo.toml
@@ -30,7 +30,7 @@ rand = "0.8"
 rust_decimal = { version = "1.7.0", features = ["tokio-pg"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqllogictest = { path = "../sqllogictest", version = "0.8" }
+sqllogictest = { path = "../sqllogictest", version = "0.9" }
 tempfile = "3"
 thiserror = "1"
 tokio = { version = "1", features = [


### PR DESCRIPTION
Also change release workflow to https://github.com/anton-yurchenko/git-release, which supports parsing Keep a Changelog format. (And the old one is actually deprecated)