### PR TITLE
ci: tweak release name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,6 @@ jobs:
         uses: anton-yurchenko/git-release@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_NAME: Release ${{ github.ref }}
+          RELEASE_NAME_PREFIX: "Release: "
         with:
           args: sqllogictest-linux-amd64.tar.gz


### PR DESCRIPTION
Currently it's
<img width="604" alt="image" src="https://user-images.githubusercontent.com/37948597/206297333-51bb5575-7a99-482a-9e57-2c048d76e498.png">

Change according to the example https://github.com/anton-yurchenko/git-release/blob/main/docs/example.md#release-title-with-prefix
