### PR TITLE
Improve the ability to parse/unparse files

### DIFF
--- a/sqllogictest/src/parser.rs
+++ b/sqllogictest/src/parser.rs
@@ -640,10 +640,23 @@ mod tests {
         let records = parse_file(filename).expect("parsing to complete");
 
         let unparsed = records
-            .into_iter()
+            .iter()
             .map(record_to_string)
             .collect::<Vec<_>>();
 
+        // Technically this will not always be the same due to some whitespace normalization
+        //
+        // query   III
+        // select * from foo;
+        // ----
+        // 1 2
+        //
+        // Will print out collaposting the spaces between `query`
+        //
+        // query III
+        // select * from foo;
+        // ----
+        // 1 2
         let output_contents = unparsed.join("\n");
 
         let changeset = Changeset::new(&input_contents, &output_contents, "\n");

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -546,7 +546,7 @@ impl<D: AsyncDB> Runner<D> {
             }
             Record::Include { .. }
             | Record::Comment(_)
-            | Record::Whitespace(_)
+            | Record::Newline
             | Record::Subtest { .. }
             | Record::Halt { .. }
             | Record::Injected(_)

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -546,6 +546,7 @@ impl<D: AsyncDB> Runner<D> {
             }
             Record::Include { .. }
             | Record::Comment(_)
+            | Record::Whitespace(_)
             | Record::Subtest { .. }
             | Record::Halt { .. }
             | Record::Injected(_)


### PR DESCRIPTION
First of all, thank you again for this library -- it is really awesome. 

# Rationale
I am trying to implement "test script completion mode" in DataFusion. In order to do so, I would like to be able to update parsed `Records` with new output and then write them back to a file. Ideally the only changes in the file would be the new results and the original file will have all the comments, whitespace, etc. 

DataFusion ticket: https://github.com/apache/arrow-datafusion/issues/4570, https://github.com/apache/arrow-datafusion/issues/4570#issuecomment-1345252492

# Changes
1. Add `impl Display` for Record (refactor `unparse`)
2. Add tests for roundtrip parsing / unparsing
3. Add `Record::Whitespace` so the whitespace in the original files can be reconstructed (found during testing)


# Questions
1. I had a question about whitespace after `Record::Statement` and `RecordQuery` which I will note inline
2. If you accept this change, I would be happy to add more round trip parsing tests for the other example files

