### PR TITLE
Make `update_test_file` not have ownership of runner

### DIFF
--- a/sqllogictest-bin/src/lib.rs
+++ b/sqllogictest-bin/src/lib.rs
@@ -1,6 +1,5 @@
 mod engines;
 
-use fs_err::{File, OpenOptions};
 use std::collections::BTreeMap;
 use std::io::{stdout, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -11,6 +10,7 @@ use chrono::Local;
 use clap::{ArgEnum, Parser};
 use console::style;
 use engines::{EngineConfig, EngineType};
+use fs_err::{File, OpenOptions};
 use futures::StreamExt;
 use itertools::Itertools;
 use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite};
@@ -403,7 +403,8 @@ async fn connect_and_run_test_file(
     Ok(result)
 }
 
-/// Different from [`Runner::run_file_async`], we re-implement it here to print some progress information.
+/// Different from [`Runner::run_file_async`], we re-implement it here to print some progress
+/// information.
 async fn run_test_file<T: std::io::Write, D: AsyncDB>(
     out: &mut T,
     mut runner: Runner<D>,
@@ -505,7 +506,8 @@ fn finish_test_file<T: std::io::Write>(
     Ok::<_, anyhow::Error>(())
 }
 
-/// Different from [`sqllogictest::update_test_file`], we re-implement it here to print some progress information.
+/// Different from [`sqllogictest::update_test_file`], we re-implement it here to print some
+/// progress information.
 async fn update_test_file<T: std::io::Write, D: AsyncDB>(
     out: &mut T,
     mut runner: Runner<D>,

--- a/sqllogictest/src/parser.rs
+++ b/sqllogictest/src/parser.rs
@@ -1,14 +1,15 @@
 //! Sqllogictest parser.
-use derivative::Derivative;
 use std::fmt;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::ColumnType;
-use crate::ParseErrorKind::InvalidIncludeFile;
+use derivative::Derivative;
 use itertools::Itertools;
 use regex::Regex;
+
+use crate::ColumnType;
+use crate::ParseErrorKind::InvalidIncludeFile;
 
 /// The location in source file.
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -1033,21 +1033,22 @@ pub fn update_record_with_output(
 /// Updates a test file with the output produced by a Database. It is an utility function wrapping
 /// [`update_test_file_with_runner`].
 ///
-/// Specifically, it will create `"{filename}.temp"` to buffer the updated records and then override the
-/// original file with it.
+/// Specifically, it will create `"{filename}.temp"` to buffer the updated records and then override
+/// the original file with it.
 ///
 /// Some other notes:
 /// - empty lines at the end of the file are cleaned.
 /// - `halt` and `include` are correctly handled.
 pub async fn update_test_file<D: AsyncDB>(
     filename: impl AsRef<Path>,
-    mut runner: Runner<D>,
+    runner: &mut Runner<D>,
     col_separator: &str,
     validator: Validator,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use fs_err::{File, OpenOptions};
     use std::io::{Read, Seek, SeekFrom, Write};
     use std::path::PathBuf;
+
+    use fs_err::{File, OpenOptions};
 
     fn create_outfile(filename: impl AsRef<Path>) -> std::io::Result<(PathBuf, File)> {
         let filename = filename.as_ref();


### PR DESCRIPTION
Signed-off-by: xudong963 <wxd963996380@gmail.com>

It's better to make `update_test_file` not have ownership of `runner`.
