### PR TITLE
fix: trim string before rowsort

### DIFF
--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -512,6 +512,15 @@ impl<D: AsyncDB> Runner<D> {
                     }
                 };
 
+                // trim strings
+                for row in &mut rows {
+                    for value in row {
+                        if value.trim() != value {
+                            *value = value.trim().to_string();
+                        }
+                    }
+                }
+
                 match sort_mode.as_ref().or(self.sort_mode.as_ref()) {
                     None | Some(SortMode::NoSort) => {}
                     Some(SortMode::RowSort) => {


### PR DESCRIPTION
Signed-off-by: Runji Wang <wangrunji0408@163.com>

If the engine returns a value with leading spaces, it will affect the result of rowsort, but won't be recognized in error message since we trim the string before reporting error but after the rowsort. This PR trims the string before rowsort to avoid this problem. Despite this, engines should not return a value with leading or tailing space.