### PR TITLE
fix: use Vec<Vec<String>> for external engine

### DIFF
--- a/sqllogictest-bin/src/engines/external.rs
+++ b/sqllogictest-bin/src/engines/external.rs
@@ -18,19 +18,19 @@ use tokio_util::codec::{Decoder, FramedRead};
 /// # Protocol
 ///
 /// Sends JSON stream:
-/// ```
+/// ```json
 /// {"sql":"SELECT 1,2"}
 /// ```
 ///
 /// Receives JSON stream:
 ///
 /// If the query succeeds:
-/// ```
+/// ```json
 /// {"result":[["1","2"]]}
 /// ```
 ///
 /// If the query fails:
-/// ```
+/// ```json
 /// {"err":"..."}
 /// ```
 pub struct ExternalDriver {

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -512,15 +512,6 @@ impl<D: AsyncDB> Runner<D> {
                     }
                 };
 
-                // trim strings
-                for row in &mut rows {
-                    for value in row {
-                        if value.trim() != value {
-                            *value = value.trim().to_string();
-                        }
-                    }
-                }
-
                 match sort_mode.as_ref().or(self.sort_mode.as_ref()) {
                     None | Some(SortMode::NoSort) => {}
                     Some(SortMode::RowSort) => {


### PR DESCRIPTION
- jdbc side: https://github.com/risinglightdb/sqllogictest-driver-jdbc/pull/6
- Also Revert "trim string before rowsort (#137)" acoording to the comments in the PR