### PR TITLE
Use lines() instead of split('\n') in parse_inner

### DIFF
--- a/sqllogictest/src/parser.rs
+++ b/sqllogictest/src/parser.rs
@@ -397,7 +397,7 @@ pub fn parse(script: &str) -> Result<Vec<Record>, ParseError> {
 
 #[allow(clippy::collapsible_match)]
 fn parse_inner(loc: &Location, script: &str) -> Result<Vec<Record>, ParseError> {
-    let mut lines = script.split('\n').enumerate();
+    let mut lines = script.lines().enumerate();
     let mut records = vec![];
     let mut conditions = vec![];
 
@@ -638,7 +638,7 @@ mod tests {
     #[test]
     fn test_include_glob() {
         let records = parse_file("../examples/include/include_1.slt").unwrap();
-        assert_eq!(16, records.len());
+        assert_eq!(15, records.len());
     }
 
     #[test]


### PR DESCRIPTION
Should fix https://github.com/apache/arrow-datafusion/issues/4494

Currently when parsing files which use `\r\n` to separate lines on Windows, the query-result separator line looks like `----\r`. This fails the `if line == "----" {` check, resulting in the whole file being swallowed as part of the query. The built-in `lines` method fixes this issue by splitting on both `\n` and `\r\n`. 

The change in the result for the `include_glob` test is due to `lines()` trimming a trailing newline from one of the included files.