### PR TITLE
fix: parse dml with ```returning``` as a query

### DIFF
--- a/sqllogictest-bin/src/engines/postgres.rs
+++ b/sqllogictest-bin/src/engines/postgres.rs
@@ -59,7 +59,10 @@ impl sqllogictest::AsyncDB for Postgres {
                 || lower_sql.starts_with("show")
                 || lower_sql.starts_with("with")
                 || lower_sql.starts_with("describe")
-                || ((lower_sql.starts_with("insert") || lower_sql.starts_with("update") || lower_sql.starts_with("delete")) && lower_sql.contains("returning"))
+                || ((lower_sql.starts_with("insert")
+                    || lower_sql.starts_with("update")
+                    || lower_sql.starts_with("delete"))
+                    && lower_sql.contains("returning"))
         };
 
         // NOTE:

--- a/sqllogictest-bin/src/engines/postgres.rs
+++ b/sqllogictest-bin/src/engines/postgres.rs
@@ -59,7 +59,7 @@ impl sqllogictest::AsyncDB for Postgres {
                 || lower_sql.starts_with("show")
                 || lower_sql.starts_with("with")
                 || lower_sql.starts_with("describe")
-                || lower_sql.contains("returning")
+                || ((lower_sql.starts_with("insert") || lower_sql.starts_with("update") || lower_sql.starts_with("delete")) && lower_sql.contains("returning"))
         };
 
         // NOTE:

--- a/sqllogictest-bin/src/engines/postgres.rs
+++ b/sqllogictest-bin/src/engines/postgres.rs
@@ -59,6 +59,7 @@ impl sqllogictest::AsyncDB for Postgres {
                 || lower_sql.starts_with("show")
                 || lower_sql.starts_with("with")
                 || lower_sql.starts_with("describe")
+                || lower_sql.contains("returning")
         };
 
         // NOTE:

--- a/sqllogictest-bin/src/engines/postgres_extended.rs
+++ b/sqllogictest-bin/src/engines/postgres_extended.rs
@@ -232,6 +232,7 @@ impl sqllogictest::AsyncDB for PostgresExtended {
                 || lower_sql.starts_with("show")
                 || lower_sql.starts_with("with")
                 || lower_sql.starts_with("describe")
+                || lower_sql.contains("returning")
         };
         if !is_query_sql {
             self.client.execute(sql, &[]).await?;

--- a/sqllogictest-bin/src/engines/postgres_extended.rs
+++ b/sqllogictest-bin/src/engines/postgres_extended.rs
@@ -232,7 +232,7 @@ impl sqllogictest::AsyncDB for PostgresExtended {
                 || lower_sql.starts_with("show")
                 || lower_sql.starts_with("with")
                 || lower_sql.starts_with("describe")
-                || lower_sql.contains("returning")
+                || ((lower_sql.starts_with("insert") || lower_sql.starts_with("update") || lower_sql.starts_with("delete")) && lower_sql.contains("returning"))
         };
         if !is_query_sql {
             self.client.execute(sql, &[]).await?;

--- a/sqllogictest-bin/src/engines/postgres_extended.rs
+++ b/sqllogictest-bin/src/engines/postgres_extended.rs
@@ -232,7 +232,10 @@ impl sqllogictest::AsyncDB for PostgresExtended {
                 || lower_sql.starts_with("show")
                 || lower_sql.starts_with("with")
                 || lower_sql.starts_with("describe")
-                || ((lower_sql.starts_with("insert") || lower_sql.starts_with("update") || lower_sql.starts_with("delete")) && lower_sql.contains("returning"))
+                || ((lower_sql.starts_with("insert")
+                    || lower_sql.starts_with("update")
+                    || lower_sql.starts_with("delete"))
+                    && lower_sql.contains("returning"))
         };
         if !is_query_sql {
             self.client.execute(sql, &[]).await?;

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -351,7 +351,7 @@ impl<'a> Display for TestErrorKindDisplay<'a> {
             } => write!(
                 f,
                 "query result mismatch:\n[SQL] {sql}\n[Diff] ({}|{})\n{}",
-                "-excepted".bright_red(),
+                "-expected".bright_red(),
                 "+actual".bright_green(),
                 difference::Changeset::new(expected, actual, "\n")
                     .diffs


### PR DESCRIPTION
Resolve issue #140
Fix a typo

Local test has passed:
<img width="918" alt="image" src="https://user-images.githubusercontent.com/52417396/210691253-0218971e-b386-4f0a-b462-c09ab50d652e.png">
