### PR TITLE
CLI: support multiple files as input

### DIFF
--- a/examples/condition/examples/condition.rs
+++ b/examples/condition/examples/condition.rs
@@ -11,7 +11,7 @@ pub struct FakeDBError;
 
 impl std::fmt::Display for FakeDBError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/examples/file_level_sort_mode/examples/file_level_sort_mode.rs
+++ b/examples/file_level_sort_mode/examples/file_level_sort_mode.rs
@@ -9,7 +9,7 @@ pub struct FakeDBError;
 
 impl std::fmt::Display for FakeDBError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/examples/include/examples/include.rs
+++ b/examples/include/examples/include.rs
@@ -9,7 +9,7 @@ pub struct FakeDBError;
 
 impl std::fmt::Display for FakeDBError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/examples/rowsort/examples/rowsort.rs
+++ b/examples/rowsort/examples/rowsort.rs
@@ -9,7 +9,7 @@ pub struct FakeDBError;
 
 impl std::fmt::Display for FakeDBError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/examples/test_dir_escape/examples/test_dir_escape.rs
+++ b/examples/test_dir_escape/examples/test_dir_escape.rs
@@ -9,7 +9,7 @@ pub struct FakeDBError;
 
 impl std::fmt::Display for FakeDBError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -20,7 +20,7 @@ impl sqllogictest::DB for FakeDB {
 
     fn run(&mut self, sql: &str) -> Result<DBOutput, FakeDBError> {
         // Output will be: sqllogictests yields copy test to '/tmp/.tmp6xSyMa/test.csv';
-        println!("sqllogictests yields {}", sql);
+        println!("sqllogictests yields {sql}");
         assert!(!sql.contains("__TEST_DIR__"));
         Ok(DBOutput::StatementComplete(0))
     }

--- a/examples/validator/examples/validator.rs
+++ b/examples/validator/examples/validator.rs
@@ -9,7 +9,7 @@ pub struct FakeDBError;
 
 impl std::fmt::Display for FakeDBError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/sqllogictest-bin/src/lib.rs
+++ b/sqllogictest-bin/src/lib.rs
@@ -171,13 +171,14 @@ pub async fn main_okk() -> Result<()> {
     }
 
     let files: Vec<PathBuf> = files
-        .iter()
-        .map(|filename| {
-            glob::glob(filename)
-                .context("failed to read glob pattern")
-                .unwrap()
-        })
-        .flat_map(|glob| glob.into_iter().try_collect::<_, Vec<_>, _>().unwrap())
+        .into_iter()
+        .map(|filename| glob::glob(&filename).context("failed to read glob pattern"))
+        .try_collect::<_, Vec<_>, _>()?
+        .into_iter()
+        .map(|glob| glob.try_collect::<_, Vec<_>, _>())
+        .try_collect::<_, Vec<_>, _>()?
+        .into_iter()
+        .flatten()
         .collect();
 
     if files.is_empty() {

--- a/sqllogictest-bin/src/lib.rs
+++ b/sqllogictest-bin/src/lib.rs
@@ -209,7 +209,7 @@ pub async fn main_okk() -> Result<()> {
     report.add_test_suite(test_suite);
 
     if let Some(junit_file) = junit {
-        tokio::fs::write(format!("{}-junit.xml", junit_file), report.to_string()?).await?;
+        tokio::fs::write(format!("{junit_file}-junit.xml"), report.to_string()?).await?;
     }
 
     result
@@ -231,7 +231,7 @@ async fn run_parallel(
             .to_str()
             .ok_or_else(|| anyhow!("not a UTF-8 filename"))?;
         let db_name = db_name.replace([' ', '.', '-'], "_");
-        eprintln!("+ Discovered Test: {}", db_name);
+        eprintln!("+ Discovered Test: {db_name}");
         if create_databases.insert(db_name.to_string(), file).is_some() {
             return Err(anyhow!("duplicated file name found: {}", db_name));
         }
@@ -241,10 +241,10 @@ async fn run_parallel(
 
     let db_names: Vec<String> = create_databases.keys().cloned().collect();
     for db_name in &db_names {
-        let query = format!("CREATE DATABASE {};", db_name);
-        eprintln!("+ {}", query);
+        let query = format!("CREATE DATABASE {db_name};");
+        eprintln!("+ {query}");
         if let Err(err) = db.run(&query).await {
-            eprintln!("  ignore error: {}", err);
+            eprintln!("  ignore error: {err}");
         }
     }
 
@@ -308,10 +308,10 @@ async fn run_parallel(
     );
 
     for db_name in db_names {
-        let query = format!("DROP DATABASE {};", db_name);
-        eprintln!("+ {}", query);
+        let query = format!("DROP DATABASE {db_name};");
+        eprintln!("+ {query}");
         if let Err(err) = db.run(&query).await {
-            eprintln!("  ignore error: {}", err);
+            eprintln!("  ignore error: {err}");
         }
     }
 
@@ -637,12 +637,12 @@ async fn update_test_file<T: std::io::Write, D: AsyncDB>(
             }
             _ => {
                 if *halt {
-                    writeln!(outfile, "{}", record)?;
+                    writeln!(outfile, "{record}")?;
                     continue;
                 }
                 if matches!(record, Record::Halt { .. }) {
                     *halt = true;
-                    writeln!(outfile, "{}", record)?;
+                    writeln!(outfile, "{record}")?;
                     continue;
                 }
                 update_record(outfile, &mut runner, record, format)

--- a/sqllogictest-bin/src/lib.rs
+++ b/sqllogictest-bin/src/lib.rs
@@ -170,16 +170,14 @@ pub async fn main_okk() -> Result<()> {
         Color::Auto => {}
     }
 
-    let files: Vec<PathBuf> = files
-        .into_iter()
-        .map(|filename| glob::glob(&filename).context("failed to read glob pattern"))
-        .try_collect::<_, Vec<_>, _>()?
-        .into_iter()
-        .map(|glob| glob.try_collect::<_, Vec<_>, _>())
-        .try_collect::<_, Vec<_>, _>()?
-        .into_iter()
-        .flatten()
-        .collect();
+    let glob_patterns = files;
+    let mut files: Vec<PathBuf> = Vec::new();
+    for glob_pattern in glob_patterns.into_iter() {
+        let pathbufs = glob::glob(&glob_pattern).context("failed to read glob pattern")?;
+        for pathbuf in pathbufs.into_iter().try_collect::<_, Vec<_>, _>()? {
+            files.push(pathbuf)
+        }
+    }
 
     if files.is_empty() {
         bail!("no test case found");

--- a/sqllogictest-bin/src/lib.rs
+++ b/sqllogictest-bin/src/lib.rs
@@ -173,7 +173,7 @@ pub async fn main_okk() -> Result<()> {
     let files: Vec<PathBuf> = files
         .iter()
         .map(|filename| {
-            glob::glob(&filename)
+            glob::glob(filename)
                 .context("failed to read glob pattern")
                 .unwrap()
         })

--- a/sqllogictest/src/parser.rs
+++ b/sqllogictest/src/parser.rs
@@ -23,7 +23,7 @@ impl fmt::Display for Location {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}", self.file, self.line)?;
         if let Some(upper) = &self.upper {
-            write!(f, "\nat {}", upper)?;
+            write!(f, "\nat {upper}")?;
         }
         Ok(())
     }
@@ -157,7 +157,7 @@ impl Record {
     /// # Panics
     /// If the record is an internally injected record which should not occur in the test file.
     pub fn unparse(&self, w: &mut impl std::io::Write) -> std::io::Result<()> {
-        write!(w, "{}", self)
+        write!(w, "{self}")
     }
 }
 
@@ -168,7 +168,7 @@ impl std::fmt::Display for Record {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Record::Include { loc: _, filename } => {
-                write!(f, "include {}", filename)
+                write!(f, "include {filename}")
             }
             Record::Statement {
                 loc: _,
@@ -184,15 +184,15 @@ impl std::fmt::Display for Record {
                         if err.as_str().is_empty() {
                             write!(f, "error")?;
                         } else {
-                            write!(f, "error {}", err)?;
+                            write!(f, "error {err}")?;
                         }
                     }
-                    (Some(cnt), None) => write!(f, "count {}", cnt)?,
+                    (Some(cnt), None) => write!(f, "count {cnt}")?,
                     (Some(_), Some(_)) => unreachable!(),
                 }
                 writeln!(f)?;
                 // statement always end with a blank line
-                writeln!(f, "{}", sql)
+                writeln!(f, "{sql}")
             }
             Record::Query {
                 loc: _,
@@ -206,8 +206,8 @@ impl std::fmt::Display for Record {
             } => {
                 write!(f, "query")?;
                 if let Some(err) = expected_error {
-                    writeln!(f, " error {}", err)?;
-                    return writeln!(f, "{}", sql);
+                    writeln!(f, " error {err}")?;
+                    return writeln!(f, "{sql}");
                 }
 
                 write!(
@@ -219,14 +219,14 @@ impl std::fmt::Display for Record {
                     write!(f, " {}", sort_mode.as_str())?;
                 }
                 if let Some(label) = label {
-                    write!(f, " {}", label)?;
+                    write!(f, " {label}")?;
                 }
                 writeln!(f)?;
-                writeln!(f, "{}", sql)?;
+                writeln!(f, "{sql}")?;
 
                 write!(f, "----")?;
                 for result in expected_results {
-                    write!(f, "\n{}", result)?;
+                    write!(f, "\n{result}")?;
                 }
                 // query always ends with a blank line
                 writeln!(f)
@@ -235,7 +235,7 @@ impl std::fmt::Display for Record {
                 write!(f, "sleep {}", humantime::format_duration(*duration))
             }
             Record::Subtest { loc: _, name } => {
-                write!(f, "subtest {}", name)
+                write!(f, "subtest {name}")
             }
             Record::Halt { loc: _ } => {
                 write!(f, "halt")
@@ -245,14 +245,14 @@ impl std::fmt::Display for Record {
             },
             Record::Condition(cond) => match cond {
                 Condition::OnlyIf { engine_name } => {
-                    write!(f, "onlyif {}", engine_name)
+                    write!(f, "onlyif {engine_name}")
                 }
                 Condition::SkipIf { engine_name } => {
-                    write!(f, "skipif {}", engine_name)
+                    write!(f, "skipif {engine_name}")
                 }
             },
             Record::HashThreshold { loc: _, threshold } => {
-                write!(f, "hash-threshold {}", threshold)
+                write!(f, "hash-threshold {threshold}")
             }
             Record::Comment(comment) => {
                 let mut iter = comment.iter();
@@ -263,7 +263,7 @@ impl std::fmt::Display for Record {
                 Ok(())
             }
             Record::Newline => Ok(()), // Display doesn't end with newline
-            Record::Injected(p) => panic!("unexpected injected record: {:?}", p),
+            Record::Injected(p) => panic!("unexpected injected record: {p:?}"),
         }
     }
 }
@@ -613,7 +613,7 @@ fn parse_file_inner(loc: Location) -> Result<Vec<Record>, ParseError> {
             };
 
             for included_file in glob::glob(&complete_filename)
-                .map_err(|e| InvalidIncludeFile(format!("{:?}", e)).at(loc.clone()))?
+                .map_err(|e| InvalidIncludeFile(format!("{e:?}")).at(loc.clone()))?
                 .filter_map(Result::ok)
             {
                 let included_file = included_file.as_os_str().to_string_lossy().to_string();
@@ -720,12 +720,11 @@ mod tests {
                     *********\n\
                     original:\n\
                     *********\n\
-                    {:#?}\n\n\
+                    {records:#?}\n\n\
                     *********\n\
                     reparsed:\n\
                     *********\n\
-                    {:#?}\n\n",
-            records, reparsed_records,
+                    {reparsed_records:#?}\n\n",
         );
     }
 

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -38,7 +38,7 @@ impl Display for ColumnType {
             ColumnType::Integer => write!(f, "I"),
             ColumnType::FloatingPoint => write!(f, "R"),
             ColumnType::Any => write!(f, "?"),
-            ColumnType::Unknown(c) => write!(f, "{}", c),
+            ColumnType::Unknown(c) => write!(f, "{c}"),
         }
     }
 }
@@ -189,7 +189,7 @@ impl Display for ParallelTestError {
         writeln!(f, "parallel test failed")?;
         write!(f, "Caused by:")?;
         for i in &self.errors {
-            writeln!(f, "{}", i)?;
+            writeln!(f, "{i}")?;
         }
         Ok(())
     }
@@ -224,7 +224,7 @@ impl ParallelTestError {
 
 impl std::fmt::Debug for TestError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 
@@ -806,7 +806,7 @@ impl<D: AsyncDB> Runner<D> {
             let db_name = db_name.replace([' ', '.', '-'], "_");
 
             self.db
-                .run(&format!("CREATE DATABASE {};", db_name))
+                .run(&format!("CREATE DATABASE {db_name};"))
                 .await
                 .expect("create db failed");
             let target = hosts[idx % hosts.len()].clone();
@@ -1144,19 +1144,19 @@ pub async fn update_test_file<D: AsyncDB>(
             }
             _ => {
                 if *halt {
-                    writeln!(outfile, "{}", record)?;
+                    writeln!(outfile, "{record}")?;
                     continue;
                 }
                 if matches!(record, Record::Halt { .. }) {
                     *halt = true;
-                    writeln!(outfile, "{}", record)?;
+                    writeln!(outfile, "{record}")?;
                     continue;
                 }
                 let record_output = runner.apply_record(record.clone()).await;
                 let record =
                     update_record_with_output(&record, &record_output, col_separator, validator)
                         .unwrap_or(record);
-                writeln!(outfile, "{}", record)?;
+                writeln!(outfile, "{record}")?;
             }
         }
     }

--- a/tests/harness.rs
+++ b/tests/harness.rs
@@ -15,7 +15,7 @@ pub struct FakeDBError;
 
 impl std::fmt::Display for FakeDBError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Yongting You <2010youy01@gmail.com>

Close [#117 ](https://github.com/risinglightdb/sqllogictest-rs/issues/117)
This PR adds multiple blob files CLI support (as #117 suggested)

The following CLI inputs have been tested locally
1. One unquoted glob
```
> ./target/debug/sqllogictest ./**/*.slt 
  ...(tests runned)
```
2. No input file
```
> ./target/debug/sqllogictest
  error: The following required arguments were not provided:
  <FILES>...

   USAGE:
   sqllogictest [OPTIONS] <FILES>...

   For more information try --help
```
3. Multiple globs
```
> ./target/debug/sqllogictest ./examples/basic/*.slt "./examples/condition/*.slt" ./examples/rowsort/rowsort.slt
    ...(tests runned)
```