### PR TITLE
feat: Customizable column types and validators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "custom_type"
+version = "0.1.0"
+dependencies = [
+ "sqllogictest",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ struct Database {...}
 
 impl sqllogictest::DB for Database {
     type Error = ...;
-    fn run(&mut self, sql: &str) -> Result<sqllogictest::DBOutput, Self::Error> {
+    type ColumnType = ...;
+    fn run(&mut self, sql: &str) -> Result<sqllogictest::DBOutput<Self::ColumnType>, Self::Error> {
         ...
     }
 }

--- a/examples/basic/examples/basic.rs
+++ b/examples/basic/examples/basic.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{ColumnType, DBOutput};
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 pub struct FakeDB;
 
@@ -17,11 +17,12 @@ impl std::error::Error for FakeDBError {}
 
 impl sqllogictest::DB for FakeDB {
     type Error = FakeDBError;
+    type ColumnType = DefaultColumnType;
 
-    fn run(&mut self, sql: &str) -> Result<DBOutput, FakeDBError> {
+    fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, FakeDBError> {
         if sql == "select * from example_basic" {
             return Ok(DBOutput::Rows {
-                types: vec![ColumnType::Text],
+                types: vec![DefaultColumnType::Text],
                 rows: vec![
                     vec!["Alice".to_string()],
                     vec!["Bob".to_string()],

--- a/examples/condition/examples/condition.rs
+++ b/examples/condition/examples/condition.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{ColumnType, DBOutput};
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 pub struct FakeDB {
     engine_name: &'static str,
@@ -19,11 +19,12 @@ impl std::error::Error for FakeDBError {}
 
 impl sqllogictest::DB for FakeDB {
     type Error = FakeDBError;
+    type ColumnType = DefaultColumnType;
 
-    fn run(&mut self, sql: &str) -> Result<DBOutput, FakeDBError> {
+    fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, FakeDBError> {
         if sql.contains(self.engine_name) {
             Ok(DBOutput::Rows {
-                types: vec![ColumnType::Text],
+                types: vec![DefaultColumnType::Text],
                 rows: vec![
                     vec!["Alice".to_string()],
                     vec!["Bob".to_string()],

--- a/examples/custom_type/Cargo.toml
+++ b/examples/custom_type/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "custom_type"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+sqllogictest = { path = "../../sqllogictest" }

--- a/examples/custom_type/custom_type.slt
+++ b/examples/custom_type/custom_type.slt
@@ -1,0 +1,6 @@
+query IB
+select * from example_typed
+----
+1 true
+2 false
+3 true

--- a/examples/custom_type/examples/custom_type.rs
+++ b/examples/custom_type/examples/custom_type.rs
@@ -1,0 +1,74 @@
+use std::path::PathBuf;
+
+use sqllogictest::{strict_column_validator, ColumnType, DBOutput};
+
+pub struct FakeDB;
+
+#[derive(Debug)]
+pub struct FakeDBError;
+
+impl std::fmt::Display for FakeDBError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for FakeDBError {}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum CustomColumnType {
+    Integer,
+    Boolean,
+    Date,
+}
+
+impl ColumnType for CustomColumnType {
+    fn from_char(value: char) -> Option<Self> {
+        match value {
+            'I' => Some(Self::Integer),
+            'B' => Some(Self::Boolean),
+            'D' => Some(Self::Date),
+            _ => None,
+        }
+    }
+
+    fn to_char(&self) -> char {
+        match self {
+            Self::Integer => 'I',
+            Self::Boolean => 'B',
+            Self::Date => 'D',
+        }
+    }
+}
+
+impl sqllogictest::DB for FakeDB {
+    type Error = FakeDBError;
+    type ColumnType = CustomColumnType;
+
+    fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, FakeDBError> {
+        if sql == "select * from example_typed" {
+            Ok(DBOutput::Rows {
+                types: vec![CustomColumnType::Integer, CustomColumnType::Boolean],
+                rows: vec![
+                    vec!["1".to_string(), "true".to_string()],
+                    vec!["2".to_string(), "false".to_string()],
+                    vec!["3".to_string(), "true".to_string()],
+                ],
+            })
+        } else {
+            Err(FakeDBError)
+        }
+    }
+}
+
+fn main() {
+    let mut tester = sqllogictest::Runner::new(FakeDB);
+    tester.with_column_validator(strict_column_validator);
+
+    let mut filename = PathBuf::from(file!());
+    filename.pop();
+    filename.pop();
+    filename.push("custom_type.slt");
+
+    tester.run_file(filename).unwrap();
+}

--- a/examples/file_level_sort_mode/examples/file_level_sort_mode.rs
+++ b/examples/file_level_sort_mode/examples/file_level_sort_mode.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{ColumnType, DBOutput};
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 pub struct FakeDB;
 
@@ -17,16 +17,17 @@ impl std::error::Error for FakeDBError {}
 
 impl sqllogictest::DB for FakeDB {
     type Error = FakeDBError;
+    type ColumnType = DefaultColumnType;
 
-    fn run(&mut self, sql: &str) -> Result<DBOutput, FakeDBError> {
+    fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, FakeDBError> {
         if sql == "select * from example_file_level_sort_mode" {
             // Even if the order is not the same as `slt` file, sqllogictest will sort them before
             // comparing.
             return Ok(DBOutput::Rows {
                 types: vec![
-                    ColumnType::Integer,
-                    ColumnType::Integer,
-                    ColumnType::Integer,
+                    DefaultColumnType::Integer,
+                    DefaultColumnType::Integer,
+                    DefaultColumnType::Integer,
                 ],
                 rows: vec![
                     vec!["1".to_string(), "10".to_string(), "2333".to_string()],

--- a/examples/include/examples/include.rs
+++ b/examples/include/examples/include.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{ColumnType, DBOutput};
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 pub struct FakeDB;
 
@@ -17,11 +17,12 @@ impl std::error::Error for FakeDBError {}
 
 impl sqllogictest::DB for FakeDB {
     type Error = FakeDBError;
+    type ColumnType = DefaultColumnType;
 
-    fn run(&mut self, sql: &str) -> Result<DBOutput, FakeDBError> {
+    fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, FakeDBError> {
         if sql == "select * from example_basic" {
             return Ok(DBOutput::Rows {
-                types: vec![ColumnType::Text],
+                types: vec![DefaultColumnType::Text],
                 rows: vec![
                     vec!["Alice".to_string()],
                     vec!["Bob".to_string()],

--- a/examples/rowsort/examples/rowsort.rs
+++ b/examples/rowsort/examples/rowsort.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{ColumnType, DBOutput};
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 pub struct FakeDB;
 
@@ -17,16 +17,17 @@ impl std::error::Error for FakeDBError {}
 
 impl sqllogictest::DB for FakeDB {
     type Error = FakeDBError;
+    type ColumnType = DefaultColumnType;
 
-    fn run(&mut self, sql: &str) -> Result<DBOutput, FakeDBError> {
+    fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, FakeDBError> {
         if sql == "select * from example_rowsort" {
             // Even if the order is not the same as `slt` file, sqllogictest will sort them before
             // comparing.
             return Ok(DBOutput::Rows {
                 types: vec![
-                    ColumnType::Integer,
-                    ColumnType::Integer,
-                    ColumnType::Integer,
+                    DefaultColumnType::Integer,
+                    DefaultColumnType::Integer,
+                    DefaultColumnType::Integer,
                 ],
                 rows: vec![
                     vec!["1".to_string(), "10".to_string(), "2333".to_string()],

--- a/examples/test_dir_escape/examples/test_dir_escape.rs
+++ b/examples/test_dir_escape/examples/test_dir_escape.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::DBOutput;
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 pub struct FakeDB;
 
@@ -17,8 +17,9 @@ impl std::error::Error for FakeDBError {}
 
 impl sqllogictest::DB for FakeDB {
     type Error = FakeDBError;
+    type ColumnType = DefaultColumnType;
 
-    fn run(&mut self, sql: &str) -> Result<DBOutput, FakeDBError> {
+    fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, FakeDBError> {
         // Output will be: sqllogictests yields copy test to '/tmp/.tmp6xSyMa/test.csv';
         println!("sqllogictests yields {sql}");
         assert!(!sql.contains("__TEST_DIR__"));

--- a/examples/validator/examples/validator.rs
+++ b/examples/validator/examples/validator.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{ColumnType, DBOutput};
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 pub struct FakeDB;
 
@@ -17,10 +17,11 @@ impl std::error::Error for FakeDBError {}
 
 impl sqllogictest::DB for FakeDB {
     type Error = FakeDBError;
+    type ColumnType = DefaultColumnType;
 
-    fn run(&mut self, _sql: &str) -> Result<DBOutput, FakeDBError> {
+    fn run(&mut self, _sql: &str) -> Result<DBOutput<Self::ColumnType>, FakeDBError> {
         Ok(DBOutput::Rows {
-            types: vec![ColumnType::Text],
+            types: vec![DefaultColumnType::Text],
             rows: vec![vec!["Hello, world!".to_string()]],
         })
     }

--- a/sqllogictest-bin/src/engines.rs
+++ b/sqllogictest-bin/src/engines.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use async_trait::async_trait;
 use clap::ArgEnum;
-use sqllogictest::{AsyncDB, DBOutput};
+use sqllogictest::{AsyncDB, DBOutput, DefaultColumnType};
 use sqllogictest_engines::external::ExternalDriver;
 use sqllogictest_engines::postgres::{PostgresConfig, PostgresExtended, PostgresSimple};
 use tokio::process::Command;
@@ -82,7 +82,7 @@ impl std::error::Error for AnyhowError {
 }
 
 impl Engines {
-    async fn run(&mut self, sql: &str) -> Result<DBOutput, anyhow::Error> {
+    async fn run(&mut self, sql: &str) -> Result<DBOutput<DefaultColumnType>, anyhow::Error> {
         Ok(match self {
             Engines::Postgres(e) => e.run(sql).await?,
             Engines::PostgresExtended(e) => e.run(sql).await?,
@@ -94,8 +94,9 @@ impl Engines {
 #[async_trait]
 impl AsyncDB for Engines {
     type Error = AnyhowError;
+    type ColumnType = DefaultColumnType;
 
-    async fn run(&mut self, sql: &str) -> Result<DBOutput, Self::Error> {
+    async fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, Self::Error> {
         self.run(sql).await.map_err(AnyhowError)
     }
 }

--- a/sqllogictest-bin/src/lib.rs
+++ b/sqllogictest-bin/src/lib.rs
@@ -673,7 +673,7 @@ async fn update_test_file<T: std::io::Write, D: AsyncDB>(
 async fn update_record<D: AsyncDB>(
     outfile: &mut File,
     runner: &mut Runner<D>,
-    record: Record,
+    record: Record<D::ColumnType>,
     format: bool,
 ) -> Result<()> {
     assert!(!matches!(record, Record::Injected(_)));

--- a/sqllogictest-engines/src/external.rs
+++ b/sqllogictest-engines/src/external.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use bytes::{Buf, BytesMut};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
-use sqllogictest::{AsyncDB, DBOutput};
+use sqllogictest::{AsyncDB, DBOutput, DefaultColumnType};
 use thiserror::Error;
 use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
@@ -91,8 +91,9 @@ impl Drop for ExternalDriver {
 #[async_trait]
 impl AsyncDB for ExternalDriver {
     type Error = ExternalDriverError;
+    type ColumnType = DefaultColumnType;
 
-    async fn run(&mut self, sql: &str) -> Result<DBOutput> {
+    async fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>> {
         let input = Input {
             sql: sql.to_string(),
         };

--- a/sqllogictest-engines/src/postgres/extended.rs
+++ b/sqllogictest-engines/src/postgres/extended.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime};
 use pg_interval::Interval;
 use postgres_types::Type;
 use rust_decimal::Decimal;
-use sqllogictest::{ColumnType, DBOutput};
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 use super::{Extended, Postgres, Result};
 
@@ -181,8 +181,9 @@ fn float8_to_str(value: &f64) -> String {
 #[async_trait]
 impl sqllogictest::AsyncDB for Postgres<Extended> {
     type Error = tokio_postgres::error::Error;
+    type ColumnType = DefaultColumnType;
 
-    async fn run(&mut self, sql: &str) -> Result<DBOutput> {
+    async fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>> {
         let mut output = vec![];
 
         let is_query_sql = {
@@ -304,12 +305,12 @@ impl sqllogictest::AsyncDB for Postgres<Extended> {
         if output.is_empty() {
             let stmt = self.client.prepare(sql).await?;
             Ok(DBOutput::Rows {
-                types: vec![ColumnType::Any; stmt.columns().len()],
+                types: vec![DefaultColumnType::Any; stmt.columns().len()],
                 rows: vec![],
             })
         } else {
             Ok(DBOutput::Rows {
-                types: vec![ColumnType::Any; output[0].len()],
+                types: vec![DefaultColumnType::Any; output[0].len()],
                 rows: output,
             })
         }

--- a/sqllogictest-engines/src/postgres/simple.rs
+++ b/sqllogictest-engines/src/postgres/simple.rs
@@ -1,15 +1,16 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use sqllogictest::{ColumnType, DBOutput};
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 use super::{Postgres, Result, Simple};
 
 #[async_trait]
 impl sqllogictest::AsyncDB for Postgres<Simple> {
     type Error = tokio_postgres::error::Error;
+    type ColumnType = DefaultColumnType;
 
-    async fn run(&mut self, sql: &str) -> Result<DBOutput> {
+    async fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>> {
         let mut output = vec![];
 
         // NOTE:
@@ -50,7 +51,7 @@ impl sqllogictest::AsyncDB for Postgres<Simple> {
             Ok(DBOutput::StatementComplete(cnt))
         } else {
             Ok(DBOutput::Rows {
-                types: vec![ColumnType::Any; output[0].len()],
+                types: vec![DefaultColumnType::Any; output[0].len()],
                 rows: output,
             })
         }

--- a/sqllogictest/src/column_type.rs
+++ b/sqllogictest/src/column_type.rs
@@ -1,0 +1,43 @@
+use std::fmt::Debug;
+
+/// This trait represents an Sqllogictest column type.
+/// An Sqllogictest column is represented with a single character.
+/// The type has to be serializable to a character.
+pub trait ColumnType: Debug + PartialEq + Eq + Clone + Send + Sync {
+    fn from_char(value: char) -> Option<Self>;
+    fn to_char(&self) -> char;
+}
+
+/// The default Sqllogictest type.
+/// The valid types are:
+/// - 'T' - text, varchar results
+/// - 'I' - integers
+/// - 'R' - floating point numbers
+/// Any other types are represented with `?`([`DefaultColumnType::Any`]).
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum DefaultColumnType {
+    Text,
+    Integer,
+    FloatingPoint,
+    Any,
+}
+
+impl ColumnType for DefaultColumnType {
+    fn from_char(value: char) -> Option<Self> {
+        match value {
+            'T' => Some(Self::Text),
+            'I' => Some(Self::Integer),
+            'R' => Some(Self::FloatingPoint),
+            _ => Some(Self::Any),
+        }
+    }
+
+    fn to_char(&self) -> char {
+        match self {
+            Self::Text => 'T',
+            Self::Integer => 'I',
+            Self::FloatingPoint => 'R',
+            Self::Any => '?',
+        }
+    }
+}

--- a/sqllogictest/src/lib.rs
+++ b/sqllogictest/src/lib.rs
@@ -34,9 +34,11 @@
 //! }
 //! ```
 
+pub mod column_type;
 pub mod parser;
 pub mod runner;
 
+pub use self::column_type::*;
 pub use self::parser::*;
 pub use self::runner::*;
 

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -1,6 +1,6 @@
 //! Sqllogictest runner.
 
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -13,57 +13,17 @@ use itertools::Itertools;
 use md5::Digest;
 use owo_colors::OwoColorize;
 use regex::Regex;
-use similar::Change;
-use similar::ChangeTag;
-use similar::TextDiff;
+use similar::{Change, ChangeTag, TextDiff};
 use tempfile::{tempdir, TempDir};
 
 use crate::parser::*;
-
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[non_exhaustive]
-pub enum ColumnType {
-    Text,
-    Integer,
-    FloatingPoint,
-    /// Do not check the type of the column.
-    Any,
-    Unknown(char),
-}
-
-impl Display for ColumnType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ColumnType::Text => write!(f, "T"),
-            ColumnType::Integer => write!(f, "I"),
-            ColumnType::FloatingPoint => write!(f, "R"),
-            ColumnType::Any => write!(f, "?"),
-            ColumnType::Unknown(c) => write!(f, "{c}"),
-        }
-    }
-}
-
-impl TryFrom<char> for ColumnType {
-    type Error = ParseErrorKind;
-
-    fn try_from(c: char) -> Result<Self, Self::Error> {
-        match c {
-            'T' => Ok(Self::Text),
-            'I' => Ok(Self::Integer),
-            'R' => Ok(Self::FloatingPoint),
-            '?' => Ok(Self::Any),
-            // FIXME:
-            // _ => Err(ParseErrorKind::InvalidType(c)),
-            _ => Ok(Self::Unknown(c)),
-        }
-    }
-}
+use crate::ColumnType;
 
 #[derive(Debug, Clone)]
-pub enum RecordOutput {
+pub enum RecordOutput<T: ColumnType> {
     Nothing,
     Query {
-        types: Vec<ColumnType>,
+        types: Vec<T>,
         rows: Vec<Vec<String>>,
         error: Option<Arc<dyn std::error::Error + Send + Sync>>,
     },
@@ -74,9 +34,9 @@ pub enum RecordOutput {
 }
 
 #[non_exhaustive]
-pub enum DBOutput {
+pub enum DBOutput<T: ColumnType> {
     Rows {
-        types: Vec<ColumnType>,
+        types: Vec<T>,
         rows: Vec<Vec<String>>,
     },
     /// A statement in the query has completed.
@@ -92,9 +52,11 @@ pub enum DBOutput {
 pub trait AsyncDB: Send {
     /// The error type of SQL execution.
     type Error: std::error::Error + Send + Sync + 'static;
+    /// The type of result columns
+    type ColumnType: ColumnType;
 
     /// Async run a SQL query and return the output.
-    async fn run(&mut self, sql: &str) -> Result<DBOutput, Self::Error>;
+    async fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, Self::Error>;
 
     /// Engine name of current database.
     fn engine_name(&self) -> &str {
@@ -115,9 +77,11 @@ pub trait AsyncDB: Send {
 pub trait DB: Send {
     /// The error type of SQL execution.
     type Error: std::error::Error + Send + Sync + 'static;
+    /// The type of result columns
+    type ColumnType: ColumnType;
 
     /// Run a SQL query and return the output.
-    fn run(&mut self, sql: &str) -> Result<DBOutput, Self::Error>;
+    fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, Self::Error>;
 
     /// Engine name of current database.
     fn engine_name(&self) -> &str {
@@ -131,14 +95,15 @@ impl<D> AsyncDB for D
 where
     D: DB,
 {
-    type Error = <D as DB>::Error;
+    type Error = D::Error;
+    type ColumnType = D::ColumnType;
 
-    async fn run(&mut self, sql: &str) -> Result<DBOutput, Self::Error> {
-        <D as DB>::run(self, sql)
+    async fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, Self::Error> {
+        D::run(self, sql)
     }
 
     fn engine_name(&self) -> &str {
-        <D as DB>::engine_name(self)
+        D::engine_name(self)
     }
 }
 
@@ -294,11 +259,14 @@ pub enum TestErrorKind {
         expected: String,
         actual: String,
     },
-    #[error("expected results are invalid: expected {expected} columns, got {actual} columns\n[SQL] {sql}")]
-    QueryResultColumnCountMismatch {
+    #[error(
+        "query columns mismatch:\n[SQL] {sql}\n{}",
+        format_column_diff(expected, actual, false)
+    )]
+    QueryResultColumnsMismatch {
         sql: String,
-        expected: usize,
-        actual: usize,
+        expected: String,
+        actual: String,
     },
 }
 
@@ -360,6 +328,17 @@ impl<'a> Display for TestErrorKindDisplay<'a> {
                     .iter_all_changes()
                     .format_with("\n", |diff, f| format_diff(&diff, f, true))
             ),
+            TestErrorKind::QueryResultColumnsMismatch {
+                sql,
+                expected,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "query columns mismatch:\n[SQL] {sql}\n{}",
+                    format_column_diff(expected, actual, true)
+                )
+            }
             _ => write!(f, "{}", self.error),
         }
     }
@@ -392,7 +371,44 @@ fn format_diff(
     }
 }
 
-/// Validator will be used by `Runner` to validate the output.
+fn format_column_diff(expected: &str, actual: &str, colorize: bool) -> String {
+    let (expected, actual) = TextDiff::from_chars(expected, actual)
+        .iter_all_changes()
+        .fold(
+            ("".to_string(), "".to_string()),
+            |(expected, actual), change| match change.tag() {
+                ChangeTag::Equal => (
+                    format!("{}{}", expected, change.value()),
+                    format!("{}{}", actual, change.value()),
+                ),
+                ChangeTag::Delete => (
+                    if colorize {
+                        format!("{}[{}]", expected, change.value().bright_red())
+                    } else {
+                        format!("{}[{}]", expected, change.value())
+                    },
+                    actual,
+                ),
+                ChangeTag::Insert => (
+                    expected,
+                    if colorize {
+                        format!("{}[{}]", actual, change.value().bright_green())
+                    } else {
+                        format!("{}[{}]", actual, change.value())
+                    },
+                ),
+            },
+        );
+    format!("[Expected] {}\n[Actual  ] {}", expected, actual)
+}
+
+/// Trim and replace multiple whitespaces with one.
+#[allow(clippy::ptr_arg)]
+fn normalize_string(s: &String) -> String {
+    s.trim().split_ascii_whitespace().join(" ")
+}
+
+/// Validator will be used by [`Runner`] to validate the output.
 ///
 /// # Default
 ///
@@ -409,11 +425,36 @@ pub fn default_validator(actual: &[Vec<String>], expected: &[String]) -> bool {
     normalized_rows == expected_results
 }
 
+/// [`Runner`] uses this validator to check that the expected column types match an actual output.
+///
+/// # Default
+///
+/// By default ([`default_column_validator`]), columns are not validated.
+pub type ColumnTypeValidator<T> = fn(actual: &Vec<T>, expected: &Vec<T>) -> bool;
+
+/// The default validator always returns success for any inputs of expected and actual sets of
+/// columns.
+pub fn default_column_validator<T: ColumnType>(_: &Vec<T>, _: &Vec<T>) -> bool {
+    true
+}
+
+/// The strict validator checks:
+/// - the number of columns is as expected
+/// - each column has the same type as expected
+pub fn strict_column_validator<T: ColumnType>(actual: &Vec<T>, expected: &Vec<T>) -> bool {
+    actual.len() == expected.len()
+        && !actual
+            .iter()
+            .zip(expected.iter())
+            .any(|(actual_column, expected_column)| actual_column != expected_column)
+}
+
 /// Sqllogictest runner.
 pub struct Runner<D: AsyncDB> {
     db: D,
     // validator is used for validate if the result of query equals to expected.
     validator: Validator,
+    column_type_validator: ColumnTypeValidator<D::ColumnType>,
     testdir: Option<TempDir>,
     sort_mode: Option<SortMode>,
     /// 0 means never hashing
@@ -426,6 +467,7 @@ impl<D: AsyncDB> Runner<D> {
         Runner {
             db,
             validator: default_validator,
+            column_type_validator: default_column_validator,
             testdir: None,
             sort_mode: None,
             hash_threshold: 0,
@@ -444,11 +486,18 @@ impl<D: AsyncDB> Runner<D> {
         self.validator = validator;
     }
 
+    pub fn with_column_validator(&mut self, validator: ColumnTypeValidator<D::ColumnType>) {
+        self.column_type_validator = validator;
+    }
+
     pub fn with_hash_threshold(&mut self, hash_threshold: usize) {
         self.hash_threshold = hash_threshold;
     }
 
-    pub async fn apply_record(&mut self, record: Record) -> RecordOutput {
+    pub async fn apply_record(
+        &mut self,
+        record: Record<D::ColumnType>,
+    ) -> RecordOutput<D::ColumnType> {
         match record {
             Record::Statement { conditions, .. } if self.should_skip(&conditions) => {
                 RecordOutput::Nothing
@@ -490,7 +539,7 @@ impl<D: AsyncDB> Runner<D> {
                 sort_mode,
 
                 // compare result in run_async
-                type_string: _,
+                expected_types: _,
                 expected_error: _,
                 expected_results: _,
                 loc: _,
@@ -503,7 +552,7 @@ impl<D: AsyncDB> Runner<D> {
                     Ok(out) => match out {
                         DBOutput::Rows { types, rows } => (types, rows),
                         DBOutput::StatementComplete(count) => {
-                            return RecordOutput::Statement { count, error: None }
+                            return RecordOutput::Statement { count, error: None };
                         }
                     },
                     Err(e) => {
@@ -511,7 +560,7 @@ impl<D: AsyncDB> Runner<D> {
                             error: Some(Arc::new(e)),
                             types: vec![],
                             rows: vec![],
-                        }
+                        };
                     }
                 };
 
@@ -570,7 +619,7 @@ impl<D: AsyncDB> Runner<D> {
     }
 
     /// Run a single record.
-    pub async fn run_async(&mut self, record: Record) -> Result<(), TestError> {
+    pub async fn run_async(&mut self, record: Record<D::ColumnType>) -> Result<(), TestError> {
         tracing::debug!(?record, "testing");
 
         match (record.clone(), self.apply_record(record).await) {
@@ -610,7 +659,7 @@ impl<D: AsyncDB> Runner<D> {
                         sql,
                         kind: RecordKind::Statement,
                     }
-                    .at(loc))
+                    .at(loc));
                 }
                 (None, None) => {
                     if let Some(expected_count) = expected_count {
@@ -648,7 +697,7 @@ impl<D: AsyncDB> Runner<D> {
                 Record::Query {
                     loc,
                     conditions: _,
-                    type_string,
+                    expected_types,
                     sort_mode: _,
                     label: _,
                     expected_error,
@@ -663,7 +712,7 @@ impl<D: AsyncDB> Runner<D> {
                             sql,
                             kind: RecordKind::Query,
                         }
-                        .at(loc))
+                        .at(loc));
                     }
                     (None, None) => {}
                     (Some(e), Some(expected_error)) => {
@@ -688,23 +737,13 @@ impl<D: AsyncDB> Runner<D> {
                     }
                 };
 
-                // check number of columns
-                if types.len() != type_string.len() {
-                    // FIXME: do not validate type-string now
-                    // return Err(TestErrorKind::QueryResultColumnCountMismatch {
-                    //     sql,
-                    //     expected: type_string.len(),
-                    //     actual: types.len(),
-                    // }
-                    // .at(loc));
-                }
-                for (t_actual, t_expected) in types.iter().zip(type_string.iter()) {
-                    if t_actual != &ColumnType::Any
-                        && t_expected != &ColumnType::Any
-                        && t_actual != t_expected
-                    {
-                        // FIXME: do not validate type-string now
+                if !(self.column_type_validator)(&types, &expected_types) {
+                    return Err(TestErrorKind::QueryResultColumnsMismatch {
+                        sql,
+                        expected: expected_types.iter().map(|c| c.to_char()).join(""),
+                        actual: types.iter().map(|c| c.to_char()).join(""),
                     }
+                    .at(loc));
                 }
 
                 if !(self.validator)(&rows, &expected_results) {
@@ -727,7 +766,7 @@ impl<D: AsyncDB> Runner<D> {
     }
 
     /// Run a single record.
-    pub fn run(&mut self, record: Record) -> Result<(), TestError> {
+    pub fn run(&mut self, record: Record<D::ColumnType>) -> Result<(), TestError> {
         futures::executor::block_on(self.run_async(record))
     }
 
@@ -736,7 +775,7 @@ impl<D: AsyncDB> Runner<D> {
     /// The runner will stop early once a halt record is seen.
     pub async fn run_multi_async(
         &mut self,
-        records: impl IntoIterator<Item = Record>,
+        records: impl IntoIterator<Item = Record<D::ColumnType>>,
     ) -> Result<(), TestError> {
         for record in records.into_iter() {
             if let Record::Halt { .. } = record {
@@ -752,7 +791,7 @@ impl<D: AsyncDB> Runner<D> {
     /// The runner will stop early once a halt record is seen.
     pub fn run_multi(
         &mut self,
-        records: impl IntoIterator<Item = Record>,
+        records: impl IntoIterator<Item = Record<D::ColumnType>>,
     ) -> Result<(), TestError> {
         block_on(self.run_multi_async(records))
     }
@@ -779,7 +818,7 @@ impl<D: AsyncDB> Runner<D> {
         block_on(self.run_file_async(filename))
     }
 
-    /// aceept the tasks, spawn jobs task to run slt test. the tasks are (AsyncDB, slt filename)
+    /// accept the tasks, spawn jobs task to run slt test. the tasks are (AsyncDB, slt filename)
     /// pairs.
     pub async fn run_parallel_async<Fut>(
         &mut self,
@@ -859,24 +898,161 @@ impl<D: AsyncDB> Runner<D> {
             .iter()
             .any(|c| c.should_skip(self.db.engine_name()))
     }
-}
 
-/// Trim and replace multiple whitespaces with one.
-#[allow(clippy::ptr_arg)]
-fn normalize_string(s: &String) -> String {
-    s.trim().split_ascii_whitespace().join(" ")
+    /// Updates a test file with the output produced by a Database. It is an utility function
+    /// wrapping [`update_test_file_with_runner`].
+    ///
+    /// Specifically, it will create `"{filename}.temp"` to buffer the updated records and then
+    /// override the original file with it.
+    ///
+    /// Some other notes:
+    /// - empty lines at the end of the file are cleaned.
+    /// - `halt` and `include` are correctly handled.
+    pub async fn update_test_file(
+        &mut self,
+        filename: impl AsRef<Path>,
+        col_separator: &str,
+        validator: Validator,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use std::io::{Read, Seek, SeekFrom, Write};
+        use std::path::PathBuf;
+
+        use fs_err::{File, OpenOptions};
+
+        fn create_outfile(filename: impl AsRef<Path>) -> std::io::Result<(PathBuf, File)> {
+            let filename = filename.as_ref();
+            let outfilename = filename.file_name().unwrap().to_str().unwrap().to_owned() + ".temp";
+            let outfilename = filename.parent().unwrap().join(outfilename);
+            // create a temp file in read-write mode
+            let outfile = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .read(true)
+                .open(&outfilename)?;
+            Ok((outfilename, outfile))
+        }
+
+        fn override_with_outfile(
+            filename: &String,
+            outfilename: &PathBuf,
+            outfile: &mut File,
+        ) -> std::io::Result<()> {
+            // check whether outfile ends with multiple newlines, which happens if
+            // - the last record is statement/query
+            // - the original file ends with multiple newlines
+
+            const N: usize = 8;
+            let mut buf = [0u8; N];
+            loop {
+                outfile.seek(SeekFrom::End(-(N as i64))).unwrap();
+                outfile.read_exact(&mut buf).unwrap();
+                let num_newlines = buf.iter().rev().take_while(|&&b| b == b'\n').count();
+                assert!(num_newlines > 0);
+
+                if num_newlines > 1 {
+                    // if so, remove the last ones
+                    outfile
+                        .set_len(outfile.metadata().unwrap().len() - num_newlines as u64 + 1)
+                        .unwrap();
+                }
+
+                if num_newlines == 1 || num_newlines < N {
+                    break;
+                }
+            }
+
+            outfile.flush()?;
+            fs_err::rename(outfilename, filename)?;
+
+            Ok(())
+        }
+
+        struct Item {
+            filename: String,
+            outfilename: PathBuf,
+            outfile: File,
+            halt: bool,
+        }
+
+        let filename = filename.as_ref();
+        let records = parse_file(filename)?;
+
+        let (outfilename, outfile) = create_outfile(filename)?;
+        let mut stack = vec![Item {
+            filename: filename.to_string_lossy().to_string(),
+            outfilename,
+            outfile,
+            halt: false,
+        }];
+
+        for record in records {
+            let Item {
+                filename,
+                outfilename,
+                outfile,
+                halt,
+            } = stack.last_mut().unwrap();
+
+            match &record {
+                Record::Injected(Injected::BeginInclude(filename)) => {
+                    let (outfilename, outfile) = create_outfile(filename)?;
+                    stack.push(Item {
+                        filename: filename.clone(),
+                        outfilename,
+                        outfile,
+                        halt: false,
+                    });
+                }
+                Record::Injected(Injected::EndInclude(_)) => {
+                    override_with_outfile(filename, outfilename, outfile)?;
+                    stack.pop();
+                }
+                _ => {
+                    if *halt {
+                        writeln!(outfile, "{record}")?;
+                        continue;
+                    }
+                    if matches!(record, Record::Halt { .. }) {
+                        *halt = true;
+                        writeln!(outfile, "{record}")?;
+                        continue;
+                    }
+                    let record_output = self.apply_record(record.clone()).await;
+                    let record = update_record_with_output(
+                        &record,
+                        &record_output,
+                        col_separator,
+                        validator,
+                    )
+                    .unwrap_or(record);
+                    writeln!(outfile, "{record}")?;
+                }
+            }
+        }
+
+        let Item {
+            filename,
+            outfilename,
+            outfile,
+            halt: _,
+        } = stack.last_mut().unwrap();
+        override_with_outfile(filename, outfilename, outfile)?;
+
+        Ok(())
+    }
 }
 
 /// Updates the specified [`Record`] with the [`QueryOutput`] produced
 /// by a Database, returning `Some(new_record)`.
 ///
 /// If an update is not supported, returns `None`
-pub fn update_record_with_output(
-    record: &Record,
-    record_output: &RecordOutput,
+pub fn update_record_with_output<T: ColumnType>(
+    record: &Record<T>,
+    record_output: &RecordOutput<T>,
     col_separator: &str,
     validator: Validator,
-) -> Option<Record> {
+) -> Option<Record<T>> {
     match (record.clone(), record_output) {
         (_, RecordOutput::Nothing) => None,
         // statement, query
@@ -964,7 +1140,7 @@ pub fn update_record_with_output(
             Record::Query {
                 loc,
                 conditions,
-                type_string,
+                expected_types,
                 sort_mode,
                 label,
                 expected_error,
@@ -988,11 +1164,11 @@ pub fn update_record_with_output(
                         expected_error: Some(expected_error),
                         loc,
                         conditions,
-                        type_string: vec![],
+                        expected_types: vec![],
                         sort_mode,
                         label,
                         expected_results: vec![],
-                    })
+                    });
                 }
                 // Error mismatch
                 (Some(e), _) => {
@@ -1001,11 +1177,11 @@ pub fn update_record_with_output(
                         expected_error: Some(Regex::new(&e.to_string()).unwrap()),
                         loc,
                         conditions,
-                        type_string: vec![],
+                        expected_types: vec![],
                         sort_mode,
                         label,
                         expected_results: vec![],
-                    })
+                    });
                 }
             };
 
@@ -1021,7 +1197,7 @@ pub fn update_record_with_output(
                 expected_error: None,
                 loc,
                 conditions,
-                type_string,
+                expected_types,
                 sort_mode,
                 label,
                 expected_results: results,
@@ -1033,148 +1209,10 @@ pub fn update_record_with_output(
     }
 }
 
-/// Updates a test file with the output produced by a Database. It is an utility function wrapping
-/// [`update_test_file_with_runner`].
-///
-/// Specifically, it will create `"{filename}.temp"` to buffer the updated records and then override
-/// the original file with it.
-///
-/// Some other notes:
-/// - empty lines at the end of the file are cleaned.
-/// - `halt` and `include` are correctly handled.
-pub async fn update_test_file<D: AsyncDB>(
-    filename: impl AsRef<Path>,
-    runner: &mut Runner<D>,
-    col_separator: &str,
-    validator: Validator,
-) -> Result<(), Box<dyn std::error::Error>> {
-    use std::io::{Read, Seek, SeekFrom, Write};
-    use std::path::PathBuf;
-
-    use fs_err::{File, OpenOptions};
-
-    fn create_outfile(filename: impl AsRef<Path>) -> std::io::Result<(PathBuf, File)> {
-        let filename = filename.as_ref();
-        let outfilename = filename.file_name().unwrap().to_str().unwrap().to_owned() + ".temp";
-        let outfilename = filename.parent().unwrap().join(outfilename);
-        // create a temp file in read-write mode
-        let outfile = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .read(true)
-            .open(&outfilename)?;
-        Ok((outfilename, outfile))
-    }
-
-    fn override_with_outfile(
-        filename: &String,
-        outfilename: &PathBuf,
-        outfile: &mut File,
-    ) -> std::io::Result<()> {
-        // check whether outfile ends with multiple newlines, which happens if
-        // - the last record is statement/query
-        // - the original file ends with multiple newlines
-
-        const N: usize = 8;
-        let mut buf = [0u8; N];
-        loop {
-            outfile.seek(SeekFrom::End(-(N as i64))).unwrap();
-            outfile.read_exact(&mut buf).unwrap();
-            let num_newlines = buf.iter().rev().take_while(|&&b| b == b'\n').count();
-            assert!(num_newlines > 0);
-
-            if num_newlines > 1 {
-                // if so, remove the last ones
-                outfile
-                    .set_len(outfile.metadata().unwrap().len() - num_newlines as u64 + 1)
-                    .unwrap();
-            }
-
-            if num_newlines == 1 || num_newlines < N {
-                break;
-            }
-        }
-
-        outfile.flush()?;
-        fs_err::rename(outfilename, filename)?;
-
-        Ok(())
-    }
-
-    struct Item {
-        filename: String,
-        outfilename: PathBuf,
-        outfile: File,
-        halt: bool,
-    }
-
-    let filename = filename.as_ref();
-    let records = parse_file(filename)?;
-
-    let (outfilename, outfile) = create_outfile(filename)?;
-    let mut stack = vec![Item {
-        filename: filename.to_string_lossy().to_string(),
-        outfilename,
-        outfile,
-        halt: false,
-    }];
-
-    for record in records {
-        let Item {
-            filename,
-            outfilename,
-            outfile,
-            halt,
-        } = stack.last_mut().unwrap();
-
-        match &record {
-            Record::Injected(Injected::BeginInclude(filename)) => {
-                let (outfilename, outfile) = create_outfile(filename)?;
-                stack.push(Item {
-                    filename: filename.clone(),
-                    outfilename,
-                    outfile,
-                    halt: false,
-                });
-            }
-            Record::Injected(Injected::EndInclude(_)) => {
-                override_with_outfile(filename, outfilename, outfile)?;
-                stack.pop();
-            }
-            _ => {
-                if *halt {
-                    writeln!(outfile, "{record}")?;
-                    continue;
-                }
-                if matches!(record, Record::Halt { .. }) {
-                    *halt = true;
-                    writeln!(outfile, "{record}")?;
-                    continue;
-                }
-                let record_output = runner.apply_record(record.clone()).await;
-                let record =
-                    update_record_with_output(&record, &record_output, col_separator, validator)
-                        .unwrap_or(record);
-                writeln!(outfile, "{record}")?;
-            }
-        }
-    }
-
-    let Item {
-        filename,
-        outfilename,
-        outfile,
-        halt: _,
-    } = stack.last_mut().unwrap();
-    override_with_outfile(filename, outfilename, outfile)?;
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::DefaultColumnType;
 
     #[test]
     fn test_query_replacement() {
@@ -1393,7 +1431,7 @@ mod tests {
     #[derive(Debug)]
     struct TestCase {
         input: &'static str,
-        record_output: RecordOutput,
+        record_output: RecordOutput<DefaultColumnType>,
         expected: Option<&'static str>,
     }
 
@@ -1428,20 +1466,20 @@ mod tests {
         }
     }
 
-    fn parse_to_record(s: &str) -> Record {
+    fn parse_to_record(s: &str) -> Record<DefaultColumnType> {
         let mut records = parse(s).unwrap();
         assert_eq!(records.len(), 1);
         records.pop().unwrap()
     }
 
     /// Returns a RecordOutput that models the successful execution of a query
-    fn query_output(rows: &[&[&str]]) -> RecordOutput {
+    fn query_output(rows: &[&[&str]]) -> RecordOutput<DefaultColumnType> {
         let rows = rows
             .iter()
             .map(|cols| cols.iter().map(|c| c.to_string()).collect::<Vec<_>>())
             .collect::<Vec<_>>();
 
-        let types = rows.iter().map(|_| ColumnType::Any).collect();
+        let types = rows.iter().map(|_| DefaultColumnType::Any).collect();
 
         RecordOutput::Query {
             types,
@@ -1451,7 +1489,7 @@ mod tests {
     }
 
     /// Returns a RecordOutput that models the error of a query
-    fn query_output_error(error_message: &str) -> RecordOutput {
+    fn query_output_error(error_message: &str) -> RecordOutput<DefaultColumnType> {
         RecordOutput::Query {
             types: vec![],
             rows: vec![],
@@ -1459,12 +1497,12 @@ mod tests {
         }
     }
 
-    fn statement_output(count: u64) -> RecordOutput {
+    fn statement_output(count: u64) -> RecordOutput<DefaultColumnType> {
         RecordOutput::Statement { count, error: None }
     }
 
     /// RecordOutput that models a statement with error
-    fn statement_output_error(error_message: &str) -> RecordOutput {
+    fn statement_output_error(error_message: &str) -> RecordOutput<DefaultColumnType> {
         RecordOutput::Statement {
             count: 0,
             error: Some(Arc::new(TestError(error_message.to_string()))),

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -659,7 +659,7 @@ impl<D: AsyncDB> Runner<D> {
                         sql,
                         kind: RecordKind::Statement,
                     }
-                    .at(loc));
+                    .at(loc))
                 }
                 (None, None) => {
                     if let Some(expected_count) = expected_count {

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -399,7 +399,7 @@ fn format_column_diff(expected: &str, actual: &str, colorize: bool) -> String {
                 ),
             },
         );
-    format!("[Expected] {}\n[Actual  ] {}", expected, actual)
+    format!("[Expected] {expected}\n[Actual  ] {actual}")
 }
 
 /// Trim and replace multiple whitespaces with one.

--- a/tests/harness.rs
+++ b/tests/harness.rs
@@ -1,4 +1,4 @@
-use sqllogictest::{ColumnType, DBOutput};
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 sqllogictest::harness!(FakeDB::new, "slt/**/*.slt");
 
@@ -23,10 +23,11 @@ impl std::error::Error for FakeDBError {}
 
 impl sqllogictest::DB for FakeDB {
     type Error = FakeDBError;
+    type ColumnType = DefaultColumnType;
 
-    fn run(&mut self, _sql: &str) -> Result<DBOutput, FakeDBError> {
+    fn run(&mut self, _sql: &str) -> Result<DBOutput<Self::ColumnType>, FakeDBError> {
         Ok(DBOutput::Rows {
-            types: vec![ColumnType::Text],
+            types: vec![DefaultColumnType::Text],
             rows: vec![vec!["I'm fake.".to_string()]],
         })
     }


### PR DESCRIPTION
Signed-off-by: Yevhenii Melnyk <melnyk.yevhenii@gmail.com>

Partially closes #36.

# Rationale for the change

I'd like to introduce column type verification for Datafusion https://github.com/apache/arrow-datafusion/issues/4499.

In order to let downstream users of `sqllogictest-rs` to define custom column types and validation strategies, I suggest introducing a pluggable column type. This way different `AsynDB` and `DB` implementations would be able to define column types beyond the original 'T','I','R' [like CocroachDB does](https://github.com/cockroachdb/cockroach/blob/899c9112188c22ec140adbeb0cf7d5761da3827d/pkg/sql/logictest/logic.go#L282-L289), or shrinking the set of columns to only having `I` [like DuckDB suggests](https://duckdb.org/dev/sqllogictest/result_verification).

# Changes

This pr introduces an interface `ColumnType` and a default implementation `DefaultColumnType` that is similar to the original Sqllites type, except that it accepts any letters and parses them as an "Any" type.

Another change is a customizable validator for columns in results. By default, the behaviour is the same as before: neither the number nor type of the columns is validated.

# Changes visible to the client

- `AsyncDB` and `DB` implementations would need to explicitly define an associated type `ColumnType`.
- The `run` method would need to change the definition  
```
from 
fn run(&mut self, sql: &str) -> Result<DBOutput> {...}

to 
fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, FakeDBError> {...}
```
- `ColumnType::Any` -> `DefaultColumnType::Any`
- The way to call `update_test_file` would change from `update_test_file(.., runner, ..)` to `runner.update_test_file(...)`
 