### PR TITLE
Customizable types follow up: complete types in update_test_file

### DIFF
--- a/examples/custom_type/custom_type.slt
+++ b/examples/custom_type/custom_type.slt
@@ -4,3 +4,8 @@ select * from example_typed
 1 true
 2 false
 3 true
+
+
+query IB
+select * from no_results
+----

--- a/examples/custom_type/examples/custom_type.rs
+++ b/examples/custom_type/examples/custom_type.rs
@@ -55,6 +55,11 @@ impl sqllogictest::DB for FakeDB {
                     vec!["3".to_string(), "true".to_string()],
                 ],
             })
+        } else if sql == "select * from no_results" {
+            Ok(DBOutput::Rows {
+                types: vec![CustomColumnType::Integer, CustomColumnType::Boolean],
+                rows: vec![],
+            })
         } else {
             Err(FakeDBError)
         }

--- a/sqllogictest-bin/src/lib.rs
+++ b/sqllogictest-bin/src/lib.rs
@@ -16,7 +16,7 @@ use itertools::Itertools;
 use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite};
 use rand::seq::SliceRandom;
 use sqllogictest::{
-    default_column_validator, default_validator, update_record_with_output, AsyncDB, Injected,
+    default_validator, strict_column_validator, update_record_with_output, AsyncDB, Injected,
     Record, Runner,
 };
 
@@ -690,7 +690,7 @@ async fn update_record<D: AsyncDB>(
         &record_output,
         "\t",
         default_validator,
-        default_column_validator,
+        strict_column_validator,
     ) {
         Some(new_record) => {
             writeln!(outfile, "{new_record}")?;

--- a/sqllogictest-bin/src/lib.rs
+++ b/sqllogictest-bin/src/lib.rs
@@ -16,7 +16,8 @@ use itertools::Itertools;
 use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite};
 use rand::seq::SliceRandom;
 use sqllogictest::{
-    default_validator, update_record_with_output, AsyncDB, Injected, Record, Runner,
+    default_column_validator, default_validator, update_record_with_output, AsyncDB, Injected,
+    Record, Runner,
 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ArgEnum)]
@@ -684,7 +685,13 @@ async fn update_record<D: AsyncDB>(
     }
 
     let record_output = runner.apply_record(record.clone()).await;
-    match update_record_with_output(&record, &record_output, "\t", default_validator) {
+    match update_record_with_output(
+        &record,
+        &record_output,
+        "\t",
+        default_validator,
+        default_column_validator,
+    ) {
         Some(new_record) => {
             writeln!(outfile, "{new_record}")?;
         }

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -1292,7 +1292,7 @@ mod tests {
     fn test_query_replacement_no_output() {
         TestCase {
             // input has no query results
-            input: "query\n\
+            input: "query III\n\
                     select * from foo;\n\
                     ----",
 


### PR DESCRIPTION
This pr introduced a way to use custom column types https://github.com/risinglightdb/sqllogictest-rs/pull/160.
But the completion code kept ignoring the types.

This pr updates the implementation to complete column types the same way results are completed.