### PR TITLE
fix(ci): lock check-semver to 0.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: cargo-semver-checks --locked
+          args: cargo-semver-checks --version ^0.17 --locked
       - name: Check semver
         run: |
          cargo semver-checks check-release -p sqllogictest


### PR DESCRIPTION
waiting for upstream fix this https://github.com/obi1kenobi/cargo-semver-checks/issues/370