### PR TITLE
Escape regex special characters in the completion mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.2] - 2023-03-24
+
+* `Runner::update_test_file` properly escapes regex special characters.
+
 ## [0.13.1] - 2023-03-16
 
 * Support postgres options.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "educe",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-bin"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-engines"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["examples/*", "sqllogictest", "sqllogictest-bin", "sqllogictest-engines", "tests"]
 
 [workspace.package]
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 homepage = "https://github.com/risinglightdb/sqllogictest-rs"
 keywords = ["sql", "database", "parser", "cli"]

--- a/examples/basic/basic.slt
+++ b/examples/basic/basic.slt
@@ -61,3 +61,16 @@ select * from example_basic
 Alice
 Bob
 Eve
+
+# error is a regex. Special characters change the meaning of a regex and have to be escaped
+statement error The operation \(describe\) is not supported. Did you mean \[describe\]\?
+desc table example_basic;
+
+statement error The operation \(describe\) is not supported. Did you mean [describe]?
+desc table example_basic;
+
+query error The operation \(describe\) is not supported. Did you mean \[describe\]\?
+desc table example_basic;
+
+query error The operation \(describe\) is not supported. Did you mean [describe]?
+desc table example_basic;

--- a/examples/basic/examples/basic.rs
+++ b/examples/basic/examples/basic.rs
@@ -5,11 +5,11 @@ use sqllogictest::{DBOutput, DefaultColumnType};
 pub struct FakeDB;
 
 #[derive(Debug)]
-pub struct FakeDBError;
+pub struct FakeDBError(String);
 
 impl std::fmt::Display for FakeDBError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", "Hey you got FakeDBError!")
+        write!(f, "{:?}", self.0)
     }
 }
 
@@ -39,7 +39,12 @@ impl sqllogictest::DB for FakeDB {
         if sql.starts_with("drop") {
             return Ok(DBOutput::StatementComplete(0));
         }
-        Err(FakeDBError)
+        if sql.starts_with("desc") {
+            return Err(FakeDBError(
+                "The operation (describe) is not supported. Did you mean [describe]?".to_string(),
+            ));
+        }
+        Err(FakeDBError("Hey you got FakeDBError!".to_string()))
     }
 }
 

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -1129,7 +1129,7 @@ pub fn update_record_with_output<T: ColumnType>(
             // Error mismatch, update expected error
             (Some(e), _) => Some(Record::Statement {
                 sql,
-                expected_error: Some(Regex::new(&e.to_string()).unwrap()),
+                expected_error: Some(Regex::new(&regex::escape(&e.to_string())).unwrap()),
                 loc,
                 conditions,
                 expected_count: None,
@@ -1174,7 +1174,7 @@ pub fn update_record_with_output<T: ColumnType>(
                 (Some(e), _) => {
                     return Some(Record::Query {
                         sql,
-                        expected_error: Some(Regex::new(&e.to_string()).unwrap()),
+                        expected_error: Some(Regex::new(&regex::escape(&e.to_string())).unwrap()),
                         loc,
                         conditions,
                         expected_types: vec![],
@@ -1423,6 +1423,86 @@ mod tests {
             expected: Some(
                 "statement error TestError: foo\n\
                  insert into foo values(2);",
+            ),
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_statement_error_special_chars() {
+        TestCase {
+            // statement expected error
+            input: "statement error tbd\n\
+                    inser into foo values(2);",
+
+            // Model a run that produced an error message that contains regex special characters
+            record_output: statement_output_error("The operation (inser) is not supported. Did you mean [insert]?"),
+
+            // expect the output includes foo
+            expected: Some(
+                "statement error TestError: The operation \\(inser\\) is not supported\\. Did you mean \\[insert\\]\\?\n\
+                 inser into foo values(2);",
+            ),
+        }
+            .run()
+    }
+
+    #[test]
+    fn test_statement_keep_error_regex_when_matches() {
+        TestCase {
+            // statement expected error
+            input: "statement error TestError: The operation \\([a-z]+\\) is not supported.*\n\
+                    inser into foo values(2);",
+
+            // Model a run that produced an error message that contains regex special characters
+            record_output: statement_output_error(
+                "The operation (inser) is not supported. Did you mean [insert]?",
+            ),
+
+            // expect the output includes foo
+            expected: Some(
+                "statement error TestError: The operation \\([a-z]+\\) is not supported.*\n\
+                 inser into foo values(2);",
+            ),
+        }
+        .run()
+    }
+
+    #[test]
+    fn test_query_error_special_chars() {
+        TestCase {
+            // statement expected error
+            input: "query error tbd\n\
+                    selec *;",
+
+            // Model a run that produced an error message that contains regex special characters
+            record_output: query_output_error("The operation (selec) is not supported. Did you mean [select]?"),
+
+            // expect the output includes foo
+            expected: Some(
+                "query error TestError: The operation \\(selec\\) is not supported\\. Did you mean \\[select\\]\\?\n\
+                 selec *;",
+            ),
+        }
+            .run()
+    }
+
+    #[test]
+    fn test_query_error_special_chars_when_matches() {
+        TestCase {
+            // statement expected error
+            input: "query error TestError: The operation \\([a-z]+\\) is not supported.*\n\
+                    selec *;",
+
+            // Model a run that produced an error message that contains regex special characters
+            record_output: query_output_error(
+                "The operation (selec) is not supported. Did you mean [select]?",
+            ),
+
+            // expect the output includes foo
+            expected: Some(
+                "query error TestError: The operation \\([a-z]+\\) is not supported.*\n\
+                 selec *;",
             ),
         }
         .run()


### PR DESCRIPTION
This pr updates the autocompletion logic for the regex special characters.
Currently, the issues lead to cryptic errors like
```
Error: query is expected to fail with error:
	DataFusion error: Error during planning: arrow_cast requires its second argument to be a constant string, got Int64(43)
but got error:
	DataFusion error: Error during planning: arrow_cast requires its second argument to be a constant string, got Int64(43)
[SQL] SELECT arrow_cast('1', 43)
at tests/sqllogictests/test_files/arrow_typeof.slt:98
```

The problem is that the autocompletion mode added the plain brachets `()` in the example above. And it should've escaped the brackets with `\(\)`. Otherwise, they are treated as a regex group.

For more details about the issue, please, see https://github.com/apache/arrow-datafusion/issues/5727

