### PR TITLE
feat: add label for `skipif` and `onlyif` conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2023-06-08
+
+* Add `--label` option for `skipif` and `onlyif` conditions.
+* Add `Runner::add_label`. Change the field names of `Condition`.
+
 ## [0.13.2] - 2023-03-24
 
 * `Runner::update_test_file` properly escapes regex special characters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.0] - 2023-06-08
 
-* Add `--label` option for `skipif` and `onlyif` conditions.
-* Add `Runner::add_label`. Change the field names of `Condition`.
+* We enhanced how `skipif` and `onlyif` works. Previously it checks against `DB::engine_name()`, and `sqllogictest-bin` didn't implement it.
+  - (parser) A minor **breaking change**: Change the field names of `Condition:: OnlyIf/SkipIf`.
+  - (runner) Add `Runner::add_label`. Now multiple labels are supported ( `DB::engine_name()` is still included). The condition evaluates to true if *any* of the provided labels match the `skipif/onlyif <lable>`.
+  - (bin) Add `--label` option to specify custom labels.
 
 ## [0.13.2] - 2023-03-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "educe",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-bin"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-engines"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["examples/*", "sqllogictest", "sqllogictest-bin", "sqllogictest-engines", "tests"]
 
 [workspace.package]
-version = "0.13.2"
+version = "0.14.0"
 edition = "2021"
 homepage = "https://github.com/risinglightdb/sqllogictest-rs"
 keywords = ["sql", "database", "parser", "cli"]

--- a/sqllogictest-bin/Cargo.toml
+++ b/sqllogictest-bin/Cargo.toml
@@ -24,8 +24,8 @@ glob = "0.3"
 itertools = "0.10"
 quick-junit = { version = "0.2" }
 rand = "0.8"
-sqllogictest = { path = "../sqllogictest", version = "0.13" }
-sqllogictest-engines = { path = "../sqllogictest-engines", version = "0.13" }
+sqllogictest = { path = "../sqllogictest", version = "0.14" }
+sqllogictest-engines = { path = "../sqllogictest-engines", version = "0.14" }
 tokio = { version = "1", features = [
     "rt",
     "rt-multi-thread",

--- a/sqllogictest-bin/Cargo.toml
+++ b/sqllogictest-bin/Cargo.toml
@@ -8,6 +8,10 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "Sqllogictest CLI."
 
+[[bin]]
+name = "sqllogictest"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = { version = "1" }
 async-trait = "0.1"

--- a/sqllogictest-bin/src/bin/sqllogictest.rs
+++ b/sqllogictest-bin/src/bin/sqllogictest.rs
@@ -1,9 +1,0 @@
-//! We use `bin/sqllogictest.rs` instead of `main.rs` so that the installed binary
-//! is named `sqllogictest` instead of `sqllogictest-bin`.
-
-use anyhow::Result;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    sqllogictest_bin::main_okk().await
-}

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -119,7 +119,8 @@ impl DBConfig {
     }
 }
 
-pub async fn main_okk() -> Result<()> {
+#[tokio::main]
+pub async fn main() -> Result<()> {
     env_logger::init();
 
     let Opt {

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -93,6 +93,15 @@ struct Opt {
     /// Reformats the test files.
     #[clap(long)]
     format: bool,
+
+    /// Add a label for conditions.
+    ///
+    /// Records with `skipif label` will be skipped if the label is present.
+    /// Records with `onlyif label` will be executed only if the label is present.
+    ///
+    /// The engine name is a label by default.
+    #[clap(long = "label")]
+    labels: Vec<String>,
 }
 
 /// Connection configuration.
@@ -138,6 +147,7 @@ pub async fn main() -> Result<()> {
         options,
         r#override,
         format,
+        labels,
     } = Opt::parse();
 
     if host.len() != port.len() {
@@ -205,9 +215,26 @@ pub async fn main() -> Result<()> {
     test_suite.set_timestamp(Local::now());
 
     let result = if let Some(jobs) = jobs {
-        run_parallel(jobs, &mut test_suite, files, &engine, config, junit.clone()).await
+        run_parallel(
+            jobs,
+            &mut test_suite,
+            files,
+            &engine,
+            config,
+            &labels,
+            junit.clone(),
+        )
+        .await
     } else {
-        run_serial(&mut test_suite, files, &engine, config, junit.clone()).await
+        run_serial(
+            &mut test_suite,
+            files,
+            &engine,
+            config,
+            &labels,
+            junit.clone(),
+        )
+        .await
     };
 
     report.add_test_suite(test_suite);
@@ -225,6 +252,7 @@ async fn run_parallel(
     files: Vec<PathBuf>,
     engine: &EngineConfig,
     config: DBConfig,
+    labels: &[String],
     junit: Option<String>,
 ) -> Result<()> {
     let mut create_databases = BTreeMap::new();
@@ -258,10 +286,13 @@ async fn run_parallel(
             config.db = db_name;
             let file = filename.to_string_lossy().to_string();
             let engine = engine.clone();
+            let labels = labels.to_vec();
             async move {
                 let (buf, res) = tokio::spawn(async move {
                     let mut buf = vec![];
-                    let res = connect_and_run_test_file(&mut buf, filename, &engine, config).await;
+                    let res =
+                        connect_and_run_test_file(&mut buf, filename, &engine, config, &labels)
+                            .await;
                     (buf, res)
                 })
                 .await
@@ -332,13 +363,17 @@ async fn run_serial(
     files: Vec<PathBuf>,
     engine: &EngineConfig,
     config: DBConfig,
+    labels: &[String],
     junit: Option<String>,
 ) -> Result<()> {
     let mut failed_case = vec![];
 
     for file in files {
         let engine = engines::connect(engine, &config).await?;
-        let runner = Runner::new(engine);
+        let mut runner = Runner::new(engine);
+        for label in labels {
+            runner.add_label(label);
+        }
 
         let filename = file.to_string_lossy().to_string();
         let test_case_name = filename.replace(['/', ' ', '.', '-'], "_");
@@ -406,9 +441,13 @@ async fn connect_and_run_test_file(
     filename: PathBuf,
     engine: &EngineConfig,
     config: DBConfig,
+    labels: &[String],
 ) -> Result<Duration> {
     let engine = engines::connect(engine, &config).await?;
-    let runner = Runner::new(engine);
+    let mut runner = Runner::new(engine);
+    for label in labels {
+        runner.add_label(label);
+    }
     let result = run_test_file(out, runner, filename).await?;
 
     Ok(result)

--- a/sqllogictest-engines/Cargo.toml
+++ b/sqllogictest-engines/Cargo.toml
@@ -19,7 +19,7 @@ postgres-types = { version = "0.2.3", features = ["derive", "with-chrono-0_4"] }
 rust_decimal = { version = "1.7.0", features = ["tokio-pg"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqllogictest = { path = "../sqllogictest", version = "0.13" }
+sqllogictest = { path = "../sqllogictest", version = "0.14" }
 thiserror = "1"
 tokio = { version = "1", features = [
     "rt",

--- a/sqllogictest/src/parser.rs
+++ b/sqllogictest/src/parser.rs
@@ -285,9 +285,9 @@ pub enum Injected {
 /// The condition to run a query.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Condition {
-    /// The statement or query is evaluated only if a config with the same name (including database engine) is seen.
+    /// The statement or query is evaluated only if the label is seen.
     OnlyIf { label: String },
-    /// The statement or query is not evaluated if a config with the same name (including database engine) is seen.
+    /// The statement or query is not evaluated if the label is seen.
     SkipIf { label: String },
 }
 

--- a/sqllogictest/src/parser.rs
+++ b/sqllogictest/src/parser.rs
@@ -292,7 +292,7 @@ pub enum Condition {
 }
 
 impl Condition {
-    /// Evaluate condition on given `targe_name`, returns whether to skip this record.
+    /// Evaluate condition on given `label`, returns whether to skip this record.
     pub(crate) fn should_skip(&self, labels: &HashSet<String>) -> bool {
         match self {
             Condition::OnlyIf { label } => !labels.contains(label),


### PR DESCRIPTION
Users can now add `--label` options to skip commands. resolve #177 

For example:
```
sqllogictest --label risingwave ... xxx.slt
```

```slt
skipif risingwave
query I
select some_features_not_supported_yet();
```

This PR also bumps version to v0.14.0.