### PR TITLE
feat: support multiple connections (sessions) in a single test file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.15.0] - 2023-07-06
+
+* Allow multiple connections to the database in a single test case, which is useful for testing the transaction behavior. This can be achieved by attaching a `connection foo` record before the query or statement.
+  - (parser) Add `Record::Connection`.
+  - (runner) **Breaking change**: Since the runner may establish multiple connections at runtime, `Runner::new` now takes a `impl MakeConnection`, which is usually a closure that returns a try-future of the `AsyncDB` instance.
+  - (bin) The connection to the database is now established lazily on the first query or statement.
 
 ## [0.14.0] - 2023-06-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "educe",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-bin"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-engines"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "connection"
+version = "0.1.0"
+dependencies = [
+ "sqllogictest",
+]
+
+[[package]]
 name = "console"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["examples/*", "sqllogictest", "sqllogictest-bin", "sqllogictest-engines", "tests"]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 homepage = "https://github.com/risinglightdb/sqllogictest-rs"
 keywords = ["sql", "database", "parser", "cli"]

--- a/examples/basic/examples/basic.rs
+++ b/examples/basic/examples/basic.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{DBOutput, DefaultColumnType};
+use sqllogictest::{DBOutput, DefaultColumnType, MakeWith};
 
 pub struct FakeDB;
 
@@ -49,7 +49,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new_once(FakeDB);
+    let mut tester = sqllogictest::Runner::new(MakeWith(|| FakeDB));
 
     let mut filename = PathBuf::from(file!());
     filename.pop();

--- a/examples/basic/examples/basic.rs
+++ b/examples/basic/examples/basic.rs
@@ -49,7 +49,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new(FakeDB);
+    let mut tester = sqllogictest::Runner::new_once(FakeDB);
 
     let mut filename = PathBuf::from(file!());
     filename.pop();

--- a/examples/basic/examples/basic.rs
+++ b/examples/basic/examples/basic.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{DBOutput, DefaultColumnType, MakeWith};
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 pub struct FakeDB;
 
@@ -49,7 +49,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new(MakeWith(|| FakeDB));
+    let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB) });
 
     let mut filename = PathBuf::from(file!());
     filename.pop();

--- a/examples/condition/examples/condition.rs
+++ b/examples/condition/examples/condition.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{DBOutput, DefaultColumnType};
+use sqllogictest::{DBOutput, DefaultColumnType, MakeWith};
 
 pub struct FakeDB {
     engine_name: &'static str,
@@ -43,7 +43,7 @@ impl sqllogictest::DB for FakeDB {
 
 fn main() {
     for engine_name in ["risinglight", "otherdb"] {
-        let mut tester = sqllogictest::Runner::new_once(FakeDB { engine_name });
+        let mut tester = sqllogictest::Runner::new(MakeWith(|| FakeDB { engine_name }));
 
         let mut filename = PathBuf::from(file!());
         filename.pop();

--- a/examples/condition/examples/condition.rs
+++ b/examples/condition/examples/condition.rs
@@ -43,7 +43,7 @@ impl sqllogictest::DB for FakeDB {
 
 fn main() {
     for engine_name in ["risinglight", "otherdb"] {
-        let mut tester = sqllogictest::Runner::new(FakeDB { engine_name });
+        let mut tester = sqllogictest::Runner::new_once(FakeDB { engine_name });
 
         let mut filename = PathBuf::from(file!());
         filename.pop();

--- a/examples/condition/examples/condition.rs
+++ b/examples/condition/examples/condition.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{DBOutput, DefaultColumnType, MakeWith};
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 pub struct FakeDB {
     engine_name: &'static str,
@@ -43,7 +43,7 @@ impl sqllogictest::DB for FakeDB {
 
 fn main() {
     for engine_name in ["risinglight", "otherdb"] {
-        let mut tester = sqllogictest::Runner::new(MakeWith(|| FakeDB { engine_name }));
+        let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB { engine_name }) });
 
         let mut filename = PathBuf::from(file!());
         filename.pop();

--- a/examples/connection/Cargo.toml
+++ b/examples/connection/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "connection"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+sqllogictest = { path = "../../sqllogictest" }

--- a/examples/connection/connection.slt
+++ b/examples/connection/connection.slt
@@ -34,6 +34,7 @@ select counter()
 ----
 1
 
+# connection only works for one record, the next one will use `default`
 query I
 select counter()
 ----

--- a/examples/connection/connection.slt
+++ b/examples/connection/connection.slt
@@ -14,6 +14,7 @@ select counter()
 ----
 1
 
+# `default` is the name of the default connection if not specified
 connection default
 query I
 select counter()
@@ -26,6 +27,7 @@ select counter()
 ----
 2
 
+# connection names are case sensitive
 connection AnOtHeR
 query I
 select counter()

--- a/examples/connection/connection.slt
+++ b/examples/connection/connection.slt
@@ -1,0 +1,38 @@
+query I
+select counter()
+----
+1
+
+query I
+select counter()
+----
+2
+
+connection another
+query I
+select counter()
+----
+1
+
+connection default
+query I
+select counter()
+----
+3
+
+connection another
+query I
+select counter()
+----
+2
+
+connection AnOtHeR
+query I
+select counter()
+----
+1
+
+query I
+select counter()
+----
+4

--- a/examples/connection/examples/connection.rs
+++ b/examples/connection/examples/connection.rs
@@ -1,0 +1,53 @@
+use std::path::PathBuf;
+
+use sqllogictest::{DBOutput, DefaultColumnType};
+
+pub struct FakeDB {
+    counter: u64,
+}
+
+impl FakeDB {
+    #[allow(clippy::unused_async)]
+    async fn connect() -> Result<Self, FakeDBError> {
+        Ok(Self { counter: 0 })
+    }
+}
+
+#[derive(Debug)]
+pub struct FakeDBError;
+
+impl std::fmt::Display for FakeDBError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for FakeDBError {}
+
+impl sqllogictest::DB for FakeDB {
+    type Error = FakeDBError;
+    type ColumnType = DefaultColumnType;
+
+    fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, FakeDBError> {
+        if sql == "select counter()" {
+            self.counter += 1;
+            Ok(DBOutput::Rows {
+                types: vec![DefaultColumnType::Integer],
+                rows: vec![vec![self.counter.to_string()]],
+            })
+        } else {
+            Err(FakeDBError)
+        }
+    }
+}
+
+fn main() {
+    let mut tester = sqllogictest::Runner::new(FakeDB::connect);
+
+    let mut filename = PathBuf::from(file!());
+    filename.pop();
+    filename.pop();
+    filename.push("connection.slt");
+
+    tester.run_file(filename).unwrap();
+}

--- a/examples/custom_type/examples/custom_type.rs
+++ b/examples/custom_type/examples/custom_type.rs
@@ -67,7 +67,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new(FakeDB);
+    let mut tester = sqllogictest::Runner::new_once(FakeDB);
     tester.with_column_validator(strict_column_validator);
 
     let mut filename = PathBuf::from(file!());

--- a/examples/custom_type/examples/custom_type.rs
+++ b/examples/custom_type/examples/custom_type.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{strict_column_validator, ColumnType, DBOutput, MakeWith};
+use sqllogictest::{strict_column_validator, ColumnType, DBOutput};
 
 pub struct FakeDB;
 
@@ -67,7 +67,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new(MakeWith(|| FakeDB));
+    let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB) });
     tester.with_column_validator(strict_column_validator);
 
     let mut filename = PathBuf::from(file!());

--- a/examples/custom_type/examples/custom_type.rs
+++ b/examples/custom_type/examples/custom_type.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{strict_column_validator, ColumnType, DBOutput};
+use sqllogictest::{strict_column_validator, ColumnType, DBOutput, MakeWith};
 
 pub struct FakeDB;
 
@@ -67,7 +67,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new_once(FakeDB);
+    let mut tester = sqllogictest::Runner::new(MakeWith(|| FakeDB));
     tester.with_column_validator(strict_column_validator);
 
     let mut filename = PathBuf::from(file!());

--- a/examples/file_level_sort_mode/examples/file_level_sort_mode.rs
+++ b/examples/file_level_sort_mode/examples/file_level_sort_mode.rs
@@ -41,7 +41,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new(FakeDB);
+    let mut tester = sqllogictest::Runner::new_once(FakeDB);
 
     let mut filename = PathBuf::from(file!());
     filename.pop();

--- a/examples/file_level_sort_mode/examples/file_level_sort_mode.rs
+++ b/examples/file_level_sort_mode/examples/file_level_sort_mode.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{DBOutput, DefaultColumnType};
+use sqllogictest::{DBOutput, DefaultColumnType, MakeWith};
 
 pub struct FakeDB;
 
@@ -41,7 +41,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new_once(FakeDB);
+    let mut tester = sqllogictest::Runner::new(MakeWith(|| FakeDB));
 
     let mut filename = PathBuf::from(file!());
     filename.pop();

--- a/examples/file_level_sort_mode/examples/file_level_sort_mode.rs
+++ b/examples/file_level_sort_mode/examples/file_level_sort_mode.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{DBOutput, DefaultColumnType, MakeWith};
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 pub struct FakeDB;
 
@@ -41,7 +41,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new(MakeWith(|| FakeDB));
+    let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB) });
 
     let mut filename = PathBuf::from(file!());
     filename.pop();

--- a/examples/include/examples/include.rs
+++ b/examples/include/examples/include.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{DBOutput, DefaultColumnType};
+use sqllogictest::{DBOutput, DefaultColumnType, MakeWith};
 
 pub struct FakeDB;
 
@@ -44,7 +44,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new_once(FakeDB);
+    let mut tester = sqllogictest::Runner::new(MakeWith(|| FakeDB));
 
     let mut filename = PathBuf::from(file!());
     filename.pop();

--- a/examples/include/examples/include.rs
+++ b/examples/include/examples/include.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{DBOutput, DefaultColumnType, MakeWith};
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 pub struct FakeDB;
 
@@ -44,7 +44,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new(MakeWith(|| FakeDB));
+    let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB) });
 
     let mut filename = PathBuf::from(file!());
     filename.pop();

--- a/examples/include/examples/include.rs
+++ b/examples/include/examples/include.rs
@@ -44,7 +44,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new(FakeDB);
+    let mut tester = sqllogictest::Runner::new_once(FakeDB);
 
     let mut filename = PathBuf::from(file!());
     filename.pop();

--- a/examples/rowsort/examples/rowsort.rs
+++ b/examples/rowsort/examples/rowsort.rs
@@ -41,7 +41,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new(FakeDB);
+    let mut tester = sqllogictest::Runner::new_once(FakeDB);
 
     let mut filename = PathBuf::from(file!());
     filename.pop();

--- a/examples/rowsort/examples/rowsort.rs
+++ b/examples/rowsort/examples/rowsort.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{DBOutput, DefaultColumnType};
+use sqllogictest::{DBOutput, DefaultColumnType, MakeWith};
 
 pub struct FakeDB;
 
@@ -41,7 +41,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new_once(FakeDB);
+    let mut tester = sqllogictest::Runner::new(MakeWith(|| FakeDB));
 
     let mut filename = PathBuf::from(file!());
     filename.pop();

--- a/examples/rowsort/examples/rowsort.rs
+++ b/examples/rowsort/examples/rowsort.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{DBOutput, DefaultColumnType, MakeWith};
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 pub struct FakeDB;
 
@@ -41,7 +41,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new(MakeWith(|| FakeDB));
+    let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB) });
 
     let mut filename = PathBuf::from(file!());
     filename.pop();

--- a/examples/test_dir_escape/examples/test_dir_escape.rs
+++ b/examples/test_dir_escape/examples/test_dir_escape.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{DBOutput, DefaultColumnType, MakeWith};
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 pub struct FakeDB;
 
@@ -28,7 +28,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new(MakeWith(|| FakeDB));
+    let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB) });
     // enable `__TEST_DIR__` override
     tester.enable_testdir();
 

--- a/examples/test_dir_escape/examples/test_dir_escape.rs
+++ b/examples/test_dir_escape/examples/test_dir_escape.rs
@@ -28,7 +28,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new(FakeDB);
+    let mut tester = sqllogictest::Runner::new_once(FakeDB);
     // enable `__TEST_DIR__` override
     tester.enable_testdir();
 

--- a/examples/test_dir_escape/examples/test_dir_escape.rs
+++ b/examples/test_dir_escape/examples/test_dir_escape.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{DBOutput, DefaultColumnType};
+use sqllogictest::{DBOutput, DefaultColumnType, MakeWith};
 
 pub struct FakeDB;
 
@@ -28,7 +28,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new_once(FakeDB);
+    let mut tester = sqllogictest::Runner::new(MakeWith(|| FakeDB));
     // enable `__TEST_DIR__` override
     tester.enable_testdir();
 

--- a/examples/validator/examples/validator.rs
+++ b/examples/validator/examples/validator.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{DBOutput, DefaultColumnType, MakeWith};
+use sqllogictest::{DBOutput, DefaultColumnType};
 
 pub struct FakeDB;
 
@@ -28,7 +28,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new(MakeWith(|| FakeDB));
+    let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB) });
     // Validator will always return true.
     tester.with_validator(|_, _| true);
 

--- a/examples/validator/examples/validator.rs
+++ b/examples/validator/examples/validator.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use sqllogictest::{DBOutput, DefaultColumnType};
+use sqllogictest::{DBOutput, DefaultColumnType, MakeWith};
 
 pub struct FakeDB;
 
@@ -28,7 +28,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new_once(FakeDB);
+    let mut tester = sqllogictest::Runner::new(MakeWith(|| FakeDB));
     // Validator will always return true.
     tester.with_validator(|_, _| true);
 

--- a/examples/validator/examples/validator.rs
+++ b/examples/validator/examples/validator.rs
@@ -28,7 +28,7 @@ impl sqllogictest::DB for FakeDB {
 }
 
 fn main() {
-    let mut tester = sqllogictest::Runner::new(FakeDB);
+    let mut tester = sqllogictest::Runner::new_once(FakeDB);
     // Validator will always return true.
     tester.with_validator(|_, _| true);
 

--- a/sqllogictest-bin/Cargo.toml
+++ b/sqllogictest-bin/Cargo.toml
@@ -24,8 +24,8 @@ glob = "0.3"
 itertools = "0.10"
 quick-junit = { version = "0.2" }
 rand = "0.8"
-sqllogictest = { path = "../sqllogictest" }
-sqllogictest-engines = { path = "../sqllogictest-engines" }
+sqllogictest = { path = "../sqllogictest", version = "0.15" }
+sqllogictest-engines = { path = "../sqllogictest-engines", version = "0.15" }
 tokio = { version = "1", features = [
     "rt",
     "rt-multi-thread",

--- a/sqllogictest-bin/Cargo.toml
+++ b/sqllogictest-bin/Cargo.toml
@@ -24,8 +24,8 @@ glob = "0.3"
 itertools = "0.10"
 quick-junit = { version = "0.2" }
 rand = "0.8"
-sqllogictest = { path = "../sqllogictest", version = "0.14" }
-sqllogictest-engines = { path = "../sqllogictest-engines", version = "0.14" }
+sqllogictest = { path = "../sqllogictest" }
+sqllogictest-engines = { path = "../sqllogictest-engines" }
 tokio = { version = "1", features = [
     "rt",
     "rt-multi-thread",

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -454,7 +454,7 @@ async fn connect_and_run_test_file(
 /// information.
 async fn run_test_file<T: std::io::Write, M: MakeConnection>(
     out: &mut T,
-    mut runner: Runner<M>,
+    mut runner: Runner<M::Conn, M>,
     filename: impl AsRef<Path>,
 ) -> Result<Duration> {
     let filename = filename.as_ref();
@@ -557,7 +557,7 @@ fn finish_test_file<T: std::io::Write>(
 /// progress information.
 async fn update_test_file<T: std::io::Write, M: MakeConnection>(
     out: &mut T,
-    mut runner: Runner<M>,
+    mut runner: Runner<M::Conn, M>,
     filename: impl AsRef<Path>,
     format: bool,
 ) -> Result<()> {
@@ -712,7 +712,7 @@ async fn update_test_file<T: std::io::Write, M: MakeConnection>(
 
 async fn update_record<M: MakeConnection>(
     outfile: &mut File,
-    runner: &mut Runner<M>,
+    runner: &mut Runner<M::Conn, M>,
     record: Record<<M::Conn as AsyncDB>::ColumnType>,
     format: bool,
 ) -> Result<()> {

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -17,7 +17,7 @@ use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite};
 use rand::seq::SliceRandom;
 use sqllogictest::{
     default_validator, strict_column_validator, update_record_with_output, AsyncDB, Injected,
-    Record, Runner,
+    MakeConnection, Record, Runner,
 };
 
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq, ArgEnum)]
@@ -370,7 +370,7 @@ async fn run_serial(
 
     for file in files {
         let engine = engines::connect(engine, &config).await?;
-        let mut runner = Runner::new(engine);
+        let mut runner = Runner::new_once(engine);
         for label in labels {
             runner.add_label(label);
         }
@@ -419,7 +419,7 @@ async fn update_test_files(
 ) -> Result<()> {
     for file in files {
         let engine = engines::connect(engine, &config).await?;
-        let runner = Runner::new(engine);
+        let runner = Runner::new_once(engine);
 
         if let Err(e) = update_test_file(&mut std::io::stdout(), runner, &file, format).await {
             {
@@ -444,7 +444,7 @@ async fn connect_and_run_test_file(
     labels: &[String],
 ) -> Result<Duration> {
     let engine = engines::connect(engine, &config).await?;
-    let mut runner = Runner::new(engine);
+    let mut runner = Runner::new_once(engine);
     for label in labels {
         runner.add_label(label);
     }
@@ -455,9 +455,9 @@ async fn connect_and_run_test_file(
 
 /// Different from [`Runner::run_file_async`], we re-implement it here to print some progress
 /// information.
-async fn run_test_file<T: std::io::Write, D: AsyncDB>(
+async fn run_test_file<T: std::io::Write, M: MakeConnection>(
     out: &mut T,
-    mut runner: Runner<D>,
+    mut runner: Runner<M>,
     filename: impl AsRef<Path>,
 ) -> Result<Duration> {
     let filename = filename.as_ref();
@@ -558,9 +558,9 @@ fn finish_test_file<T: std::io::Write>(
 
 /// Different from [`sqllogictest::update_test_file`], we re-implement it here to print some
 /// progress information.
-async fn update_test_file<T: std::io::Write, D: AsyncDB>(
+async fn update_test_file<T: std::io::Write, M: MakeConnection>(
     out: &mut T,
-    mut runner: Runner<D>,
+    mut runner: Runner<M>,
     filename: impl AsRef<Path>,
     format: bool,
 ) -> Result<()> {
@@ -713,10 +713,10 @@ async fn update_test_file<T: std::io::Write, D: AsyncDB>(
     Ok(())
 }
 
-async fn update_record<D: AsyncDB>(
+async fn update_record<M: MakeConnection>(
     outfile: &mut File,
-    runner: &mut Runner<D>,
-    record: Record<D::ColumnType>,
+    runner: &mut Runner<M>,
+    record: Record<<M::D as AsyncDB>::ColumnType>,
     format: bool,
 ) -> Result<()> {
     assert!(!matches!(record, Record::Injected(_)));

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -369,8 +369,7 @@ async fn run_serial(
     let mut failed_case = vec![];
 
     for file in files {
-        let engine = engines::connect(engine, &config).await?;
-        let mut runner = Runner::new_once(engine);
+        let mut runner = Runner::new(|| engines::connect(engine, &config));
         for label in labels {
             runner.add_label(label);
         }
@@ -418,8 +417,7 @@ async fn update_test_files(
     format: bool,
 ) -> Result<()> {
     for file in files {
-        let engine = engines::connect(engine, &config).await?;
-        let runner = Runner::new_once(engine);
+        let runner = Runner::new(|| engines::connect(engine, &config));
 
         if let Err(e) = update_test_file(&mut std::io::stdout(), runner, &file, format).await {
             {
@@ -443,8 +441,7 @@ async fn connect_and_run_test_file(
     config: DBConfig,
     labels: &[String],
 ) -> Result<Duration> {
-    let engine = engines::connect(engine, &config).await?;
-    let mut runner = Runner::new_once(engine);
+    let mut runner = Runner::new(|| engines::connect(engine, &config));
     for label in labels {
         runner.add_label(label);
     }

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -716,7 +716,7 @@ async fn update_test_file<T: std::io::Write, M: MakeConnection>(
 async fn update_record<M: MakeConnection>(
     outfile: &mut File,
     runner: &mut Runner<M>,
-    record: Record<<M::D as AsyncDB>::ColumnType>,
+    record: Record<<M::Conn as AsyncDB>::ColumnType>,
     format: bool,
 ) -> Result<()> {
     assert!(!matches!(record, Record::Injected(_)));

--- a/sqllogictest-engines/Cargo.toml
+++ b/sqllogictest-engines/Cargo.toml
@@ -19,7 +19,7 @@ postgres-types = { version = "0.2.3", features = ["derive", "with-chrono-0_4"] }
 rust_decimal = { version = "1.7.0", features = ["tokio-pg"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqllogictest = { path = "../sqllogictest", version = "0.14" }
+sqllogictest = { path = "../sqllogictest" }
 thiserror = "1"
 tokio = { version = "1", features = [
     "rt",

--- a/sqllogictest-engines/Cargo.toml
+++ b/sqllogictest-engines/Cargo.toml
@@ -19,7 +19,7 @@ postgres-types = { version = "0.2.3", features = ["derive", "with-chrono-0_4"] }
 rust_decimal = { version = "1.7.0", features = ["tokio-pg"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqllogictest = { path = "../sqllogictest" }
+sqllogictest = { path = "../sqllogictest", version = "0.15" }
 thiserror = "1"
 tokio = { version = "1", features = [
     "rt",

--- a/sqllogictest/src/connection.rs
+++ b/sqllogictest/src/connection.rs
@@ -33,19 +33,6 @@ where
     }
 }
 
-/// Make connections with a synchronous infallible function.
-#[derive(Debug)]
-pub struct MakeWith<F>(pub F);
-
-impl<F: FnMut() -> D, D: AsyncDB> MakeConnection for MakeWith<F> {
-    type Conn = D;
-    type MakeFuture = futures::future::Ready<Result<D, D::Error>>;
-
-    fn make(&mut self) -> Self::MakeFuture {
-        futures::future::ready(Ok((self.0)()))
-    }
-}
-
 /// Connections established in a [`Runner`](crate::Runner).
 pub(crate) struct Connections<M: MakeConnection> {
     make_conn: M,

--- a/sqllogictest/src/connection.rs
+++ b/sqllogictest/src/connection.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+use std::future::IntoFuture;
+
+use futures::Future;
+
+use crate::{AsyncDB, Connection as ConnectionName, DBOutput};
+
+/// Trait for making connections to an [`AsyncDB`].
+///
+/// This is introduced to allow querying the database with different connections
+/// (then generally different sessions) in a single test file with `connection` records.
+pub trait MakeConnection {
+    /// The database type.
+    type Conn: AsyncDB;
+    /// The future returned by [`MakeConnection::make`].
+    type MakeFuture: Future<Output = Result<Self::Conn, <Self::Conn as AsyncDB>::Error>>;
+
+    /// Creates a new connection to the database.
+    fn make(&mut self) -> Self::MakeFuture;
+}
+
+/// Make connections directly from a closure returning a future.
+impl<D: AsyncDB, F, Fut> MakeConnection for F
+where
+    F: FnMut() -> Fut,
+    Fut: IntoFuture<Output = Result<D, D::Error>>,
+{
+    type Conn = D;
+    type MakeFuture = Fut::IntoFuture;
+
+    fn make(&mut self) -> Self::MakeFuture {
+        self().into_future()
+    }
+}
+
+/// Make connections with a synchronous infallible function.
+#[derive(Debug)]
+pub struct MakeWith<F>(pub F);
+
+impl<F: FnMut() -> D, D: AsyncDB> MakeConnection for MakeWith<F> {
+    type Conn = D;
+    type MakeFuture = futures::future::Ready<Result<D, D::Error>>;
+
+    fn make(&mut self) -> Self::MakeFuture {
+        futures::future::ready(Ok((self.0)()))
+    }
+}
+
+/// Connections established in a [`Runner`](crate::Runner).
+pub(crate) struct Connections<M: MakeConnection> {
+    make_conn: M,
+    conns: HashMap<ConnectionName, M::Conn>,
+}
+
+impl<M: MakeConnection> Connections<M> {
+    pub fn new(make_conn: M) -> Self {
+        Connections {
+            make_conn,
+            conns: HashMap::new(),
+        }
+    }
+
+    /// Get a connection by name. Make a new connection if it doesn't exist.
+    pub async fn get(
+        &mut self,
+        name: ConnectionName,
+    ) -> Result<&mut M::Conn, <M::Conn as AsyncDB>::Error> {
+        use std::collections::hash_map::Entry;
+
+        let conn = match self.conns.entry(name) {
+            Entry::Occupied(o) => o.into_mut(),
+            Entry::Vacant(v) => {
+                let conn = self.make_conn.make().await?;
+                v.insert(conn)
+            }
+        };
+
+        Ok(conn)
+    }
+
+    /// Run a SQL statement on the default connection.
+    ///
+    /// This is a shortcut for calling `get(Default)` then `run`.
+    pub async fn run_default(
+        &mut self,
+        sql: &str,
+    ) -> Result<DBOutput<<M::Conn as AsyncDB>::ColumnType>, <M::Conn as AsyncDB>::Error> {
+        self.get(ConnectionName::Default).await?.run(sql).await
+    }
+}

--- a/sqllogictest/src/harness.rs
+++ b/sqllogictest/src/harness.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 pub use glob::glob;
 pub use libtest_mimic::{run, Arguments, Failed, Trial};
 
-use crate::{AsyncDB, Runner};
+use crate::{AsyncDB, MakeOnce, Runner};
 
 /// * `db_fn`: `fn() -> sqllogictest::AsyncDB`
 /// * `pattern`: The glob used to match against and select each file to be tested. It is relative to
@@ -33,7 +33,7 @@ macro_rules! harness {
 }
 
 pub fn test(filename: impl AsRef<Path>, db: impl AsyncDB) -> Result<(), Failed> {
-    let mut tester = Runner::new(db);
+    let mut tester = Runner::new(MakeOnce::new(db));
     tester.run_file(filename)?;
     Ok(())
 }

--- a/sqllogictest/src/harness.rs
+++ b/sqllogictest/src/harness.rs
@@ -19,7 +19,7 @@ macro_rules! harness {
                 let path = entry.expect("failed to read glob entry");
                 tests.push($crate::harness::Trial::test(
                     path.to_str().unwrap().to_string(),
-                    move || $crate::harness::test(&path, $crate::MakeWith($db_fn)),
+                    move || $crate::harness::test(&path, || async { Ok($db_fn()) }),
                 ));
             }
 

--- a/sqllogictest/src/lib.rs
+++ b/sqllogictest/src/lib.rs
@@ -35,10 +35,12 @@
 //! ```
 
 pub mod column_type;
+pub mod connection;
 pub mod parser;
 pub mod runner;
 
 pub use self::column_type::*;
+pub use self::connection::*;
 pub use self::parser::*;
 pub use self::runner::*;
 


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

[DuckDB's sqllogictest implementation](https://duckdb.org/dev/sqllogictest/multiple_connections) provides the ability for establishing multiple connections in an `slt` file and specify which to use for each query or statement, which is helpful for testing database transactions.

This PR implements a similar feature, except that we will use a line `connection <name>` instead of the DuckDB's syntax since it is already utilized by our error matching feature.

This is a breaking change to the interfaces of the library crate (like `Runner::new`), so maybe we need to bump the minor version under `0`.