### PR TITLE
fix(bin): do not print stack backtrace on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.15.2] - 2023-07-31
+
+* fix(bin): do not print stack backtrace on error
+
 ## [0.15.1] - 2023-07-24
 
 * fix `statement error` unexpectedly passed when result is a successful `query`. Similarly for expected `query error` but successful `statement ok`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "async-trait",
  "educe",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-bin"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-engines"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["sqllogictest", "sqllogictest-bin", "sqllogictest-engines", "tests"]
 
 [workspace.package]
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 homepage = "https://github.com/risinglightdb/sqllogictest-rs"
 keywords = ["sql", "database", "parser", "cli"]

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -328,7 +328,7 @@ async fn run_parallel(
                 case
             }
             Err(e) => {
-                writeln!(buf, "{}\n\n{:?}", style("[FAILED]").red().bold(), e)?;
+                writeln!(buf, "{}\n\n{}", style("[FAILED]").red().bold(), e)?;
                 writeln!(buf)?;
                 failed_case.push(file.clone());
                 let mut status = TestCaseStatus::non_success(NonSuccessKind::Failure);


### PR DESCRIPTION
... because it's totally noise for users