### PR TITLE
fix error context display & update release workflow

### DIFF
--- a/.github/workflows/release-notes.py
+++ b/.github/workflows/release-notes.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import pathlib
+import sys
+
+
+_STDIO = pathlib.Path("-")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--input", type=pathlib.Path, default="CHANGELOG.md")
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("-o", "--output", type=pathlib.Path, required=True)
+    args = parser.parse_args()
+
+    if args.input == _STDIO:
+        lines = sys.stdin.readlines()
+    else:
+        with args.input.open() as fh:
+            lines = fh.readlines()
+    version = args.tag.lstrip("v")
+
+    note_lines = []
+    for line in lines:
+        if line.startswith("## ") and version in line:
+            note_lines.append(line)
+        elif note_lines and line.startswith("## "):
+            break
+        elif note_lines:
+            note_lines.append(line)
+
+    notes = "".join(note_lines).strip()
+    if args.output == _STDIO:
+        print(notes)
+    else:
+        args.output.write_text(notes)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,12 @@ on:
   push:
     tags:
     - "v*.*.*"
+  pull_request:
+    branches:
+    - main
 env:
   BIN_NAME: sqllogictest
+  RELEASE_VERSION: v0.15.3
 jobs:
   create-release:
     name: create-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,33 +1,108 @@
+# Reference: https://github.com/crate-ci/typos/blob/f8d11b3a696122fde2fee567dc70c0864683b481/.github/workflows/post-release.yml
+
+name: post-release
 on:
   push:
     tags:
-      - "v*"
-
-name: Release
-
+    - "v*.*.*"
+env:
+  BIN_NAME: sqllogictest
 jobs:
-  release:
-    name: Release
-    runs-on: ubuntu-22.04
+  create-release:
+    name: create-release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.release.outputs.upload_url }}
+      release_version: ${{ env.RELEASE_VERSION }}
     steps:
-      - uses: actions/checkout@v2
-        name: Checkout 🛎️
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: rustfmt, clippy
-      - uses: actions-rs/cargo@v1
-        name: Compile all targets 🚀
-        with:
-          command: build
-          args: --workspace --release
-      - name: create tar
-        run: tar -cvzf sqllogictest-linux-amd64.tar.gz -C target/release sqllogictest
-      - name: release
-        uses: anton-yurchenko/git-release@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_NAME_PREFIX: "Release: "
-        with:
-          args: sqllogictest-linux-amd64.tar.gz
+    - name: Get the release version from the tag
+      shell: bash
+      if: env.RELEASE_VERSION == ''
+      run: |
+        # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
+        echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        echo "version is: ${{ env.RELEASE_VERSION }}"
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+    - name: Generate Release Notes
+      run: |
+        ./.github/workflows/release-notes.py --tag ${{ env.RELEASE_VERSION }} --output notes-${{ env.RELEASE_VERSION }}.md
+        cat notes-${{ env.RELEASE_VERSION }}.md
+    - name: Create GitHub release
+      id: release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ env.RELEASE_VERSION }}
+        release_name: ${{ env.RELEASE_VERSION }}
+        body_path: notes-${{ env.RELEASE_VERSION }}.md
+  build-release:
+    name: build-release
+    needs: create-release
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [linux, macos, win-msvc]
+        include:
+        - build: linux
+          os: ubuntu-20.04
+          rust: stable
+          target: x86_64-unknown-linux-musl
+        - build: macos
+          os: macos-latest
+          rust: stable
+          target: x86_64-apple-darwin
+        - build: win-msvc
+          os: windows-2019
+          rust: stable
+          target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+    - name: Install packages (Ubuntu)
+      if: matrix.os == 'ubuntu-20.04'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends xz-utils liblz4-tool musl-tools
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        profile: minimal
+        override: true
+        target: ${{ matrix.target }}
+    - name: Build release binary
+      run: cargo build -p sqllogictest-bin --target ${{ matrix.target }} --verbose --release
+    - name: Build archive
+      shell: bash
+      run: |
+        outdir="./target/${{ env.TARGET_DIR }}/release"
+        staging="${{ env.BIN_NAME }}-${{ needs.create-release.outputs.release_version }}-${{ matrix.target }}"
+        mkdir -p "$staging"/{complete,doc}
+        cp {README.md,LICENSE-*} "$staging/"
+        cp {CHANGELOG.md,docs/*} "$staging/doc/"
+        if [ "${{ matrix.os }}" = "windows-2019" ]; then
+          cp "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}.exe" "$staging/"
+          cd "$staging"
+          7z a "../$staging.zip" .
+          echo "ASSET=$staging.zip" >> $GITHUB_ENV
+        else
+          cp "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}" "$staging/"
+          tar czf "$staging.tar.gz" -C "$staging" .
+          echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
+        fi
+    - name: Upload release archive
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create-release.outputs.upload_url }}
+        asset_path: ${{ env.ASSET }}
+        asset_name: ${{ env.ASSET }}
+        asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
     - main
 env:
   BIN_NAME: sqllogictest
+  CRATE_NAME: sqllogictest-bin
   RELEASE_VERSION: v0.15.3
 jobs:
   create-release:
@@ -86,7 +87,7 @@ jobs:
       shell: bash
       run: |
         outdir="./target/${{ env.TARGET_DIR }}/release"
-        staging="${{ env.BIN_NAME }}-${{ needs.create-release.outputs.release_version }}-${{ matrix.target }}"
+        staging="${{ env.CRATE_NAME }}-${{ needs.create-release.outputs.release_version }}-${{ matrix.target }}"
         mkdir -p "$staging"/{complete,doc}
         cp {README.md,LICENSE-*} "$staging/"
         cp {CHANGELOG.md,docs/*} "$staging/doc/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,18 +49,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [linux, macos, win-msvc]
         include:
-        - build: linux
-          os: ubuntu-20.04
+        - os: ubuntu-20.04
           rust: stable
           target: x86_64-unknown-linux-musl
-        - build: macos
-          os: macos-latest
+        - os: macos-latest
           rust: stable
           target: x86_64-apple-darwin
-        - build: win-msvc
-          os: windows-2019
+        - os: macos-latest
+          rust: stable
+          target: aarch64-apple-darwin
+        - os: windows-2019
           rust: stable
           target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,11 @@ on:
   push:
     tags:
     - "v*.*.*"
-  pull_request:
-    branches:
-    - main
+
 env:
   BIN_NAME: sqllogictest
   CRATE_NAME: sqllogictest-bin
-  RELEASE_VERSION: v0.15.3
+
 jobs:
   create-release:
     name: create-release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.15.3] - 2023-08-02
+
+* fix(bin): fix error context display. To avoid stack backtrace being printed, unset `RUST_BACKTRACE` environment variable, or use pre-built binaries built with stable toolchain instead.
+
 ## [0.15.2] - 2023-07-31
 
 * fix(bin): do not print stack backtrace on error

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "async-trait",
  "educe",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-bin"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-engines"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["sqllogictest", "sqllogictest-bin", "sqllogictest-engines", "tests"]
 
 [workspace.package]
-version = "0.15.2"
+version = "0.15.3"
 edition = "2021"
 homepage = "https://github.com/risinglightdb/sqllogictest-rs"
 keywords = ["sql", "database", "parser", "cli"]

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -328,7 +328,7 @@ async fn run_parallel(
                 case
             }
             Err(e) => {
-                writeln!(buf, "{}\n\n{}", style("[FAILED]").red().bold(), e)?;
+                writeln!(buf, "{}\n\n{:?}", style("[FAILED]").red().bold(), e)?;
                 writeln!(buf)?;
                 failed_case.push(file.clone());
                 let mut status = TestCaseStatus::non_success(NonSuccessKind::Failure);


### PR DESCRIPTION
revert #189. Error context is printed only for `{:?}`.

For backtrace, according to anyhow's doc,

> If using the nightly channel, or stable with features = ["backtrace"], a backtrace is captured and printed with the error if the underlying error type does not already provide its own. In order to see backtraces, they must be enabled through the environment variables described in std::backtrace

So we can either: ship pre-built binary which is built by stable or unset `RUST_BACKTRACE` to hide backtrace.

---

Also update release workflow close https://github.com/risinglightdb/sqllogictest-rs/issues/182