### PR TITLE
fix: fix parallel testing db name duplication

### DIFF
--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -267,11 +267,9 @@ async fn run_parallel(
     let mut create_databases = BTreeMap::new();
     for file in files {
         let db_name = file
-            .file_name()
-            .ok_or_else(|| anyhow!("not a valid filename"))?
             .to_str()
             .ok_or_else(|| anyhow!("not a UTF-8 filename"))?;
-        let db_name = db_name.replace([' ', '.', '-'], "_");
+        let db_name = db_name.replace([' ', '.', '-', '/'], "_");
         eprintln!("+ Discovered Test: {db_name}");
         if create_databases.insert(db_name.to_string(), file).is_some() {
             return Err(anyhow!("duplicated file name found: {}", db_name));


### PR DESCRIPTION
For slt file structure like:

```
- a
  - foo.slt
- b
  - foo.slt
```

sqllogictest-bin will report `duplicated file name found` before this PR. See https://buildkite.com/risingwavelabs/pull-request/builds/31646#018a92e8-75f8-48f6-8777-cf2ecb592775