### PR TITLE
fix: inherit configuration in `run_parallel`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: cargo-semver-checks --version ^0.27 --locked
+          args: cargo-semver-checks --version ^0.32 --locked
       - name: Check semver
         run: |
          cargo semver-checks check-release -p sqllogictest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* fix(runner): when running in parallel, the runner will correctly inherit configuration like `sort_mode` and `labels` from the main runner.
+
 ## [0.20.4] - 2024-06-06
 
 * bump dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.20.5] - 2024-06-20
+
 * fix(runner): when running in parallel, the runner will correctly inherit configuration like `sort_mode` and `labels` from the main runner.
 
 ## [0.20.4] - 2024-06-06

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "async-trait",
  "educe",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-bin"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-engines"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["sqllogictest", "sqllogictest-bin", "sqllogictest-engines", "tests"]
 
 [workspace.package]
-version = "0.20.4"
+version = "0.20.5"
 edition = "2021"
 homepage = "https://github.com/risinglightdb/sqllogictest-rs"
 keywords = ["sql", "database", "parser", "cli"]

--- a/sqllogictest/src/connection.rs
+++ b/sqllogictest/src/connection.rs
@@ -34,7 +34,6 @@ where
 }
 
 /// Connections established in a [`Runner`](crate::Runner).
-#[derive(Clone)]
 pub(crate) struct Connections<D, M> {
     make_conn: M,
     conns: HashMap<ConnectionName, D>,

--- a/sqllogictest/src/connection.rs
+++ b/sqllogictest/src/connection.rs
@@ -34,6 +34,7 @@ where
 }
 
 /// Connections established in a [`Runner`](crate::Runner).
+#[derive(Clone)]
 pub(crate) struct Connections<D, M> {
     make_conn: M,
     conns: HashMap<ConnectionName, D>,

--- a/sqllogictest/src/substitution.rs
+++ b/sqllogictest/src/substitution.rs
@@ -1,14 +1,14 @@
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use subst::Env;
 use tempfile::{tempdir, TempDir};
 
 /// Substitute environment variables and special variables like `__TEST_DIR__` in SQL.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub(crate) struct Substitution {
     /// The temporary directory for `__TEST_DIR__`.
     /// Lazily initialized and cleaned up when dropped.
-    test_dir: OnceLock<TempDir>,
+    test_dir: Arc<OnceLock<TempDir>>,
 }
 
 impl<'a> subst::VariableMap<'a> for Substitution {


### PR DESCRIPTION
In `Runner`, we create a new runner for each parallelism without reusing `self.conn`, which is not good. What's worse is that we don't inherit other fields from `self`, resulting in `add_label` not taking effect when running in parallel.