### PR TITLE
feat: change `sh` to `bash`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * runner: `RecordOutput` is now returned by `Runner::run` (or `Runner::run_async`). This allows users to access the output of each record, or check whether the record is skipped.
 * runner(substitution): add a special variable `__NOW__` which will be replaced with the current Unix timestamp in nanoseconds.
 * runner(substitution): for `system` commands, we do not substitute environment variables any more, because the shell can do that. It's necessary to escape like `\\` any more. `$__TEST_DIR__`, and are still supported.
+* runner(system): change `sh` to `bash`.
 
 ## [0.20.6] - 2024-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.21.0] - 2024-06-28
+## [0.21.0] - 2024-06-30
 
 **Breaking changes**:
 * runner: `RecordOutput` is now returned by `Runner::run` (or `Runner::run_async`). This allows users to access the output of each record, or check whether the record is skipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.17.0] - 2023-09-19
 
-* Support environment variables substituion for SQL and system commands.
+* Support environment variables substitution for SQL and system commands.
   For compatibility, this feature is by default disabled, and can be enabled by adding `control substitution on` to the test file.
   ```
   control substitution on
@@ -172,7 +172,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * We enhanced how `skipif` and `onlyif` works. Previously it checks against `DB::engine_name()`, and `sqllogictest-bin` didn't implement it.
   - (parser) A minor **breaking change**: Change the field names of `Condition:: OnlyIf/SkipIf`.
-  - (runner) Add `Runner::add_label`. Now multiple labels are supported ( `DB::engine_name()` is still included). The condition evaluates to true if *any* of the provided labels match the `skipif/onlyif <lable>`.
+  - (runner) Add `Runner::add_label`. Now multiple labels are supported ( `DB::engine_name()` is still included). The condition evaluates to true if *any* of the provided labels match the `skipif/onlyif <label>`.
   - (bin) Add `--label` option to specify custom labels.
 
 ## [0.13.2] - 2023-03-24

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ exit 1
 
 # Check the output of the command. Same as `error`, empty lines (not consecutive) are allowed, and 2 consecutive empty lines ends the result.
 system ok
-echo "Hello\n\nWorld"
+echo $'Hello\n\nWorld'
 ----
 Hello
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ echo $USER
 xxchan
 ```
 
-### Extension: Environment variable substituion in query and statement
+### Extension: Environment variable substitution in query and statement
 
 It needs to be enabled by adding `control substitution on` to the test file.
 
@@ -168,7 +168,7 @@ echo "foo" > "$__TEST_DIR__/foo.txt"
 
 > [!NOTE]
 >
-> When substitution is on, special characters need to be excaped, e.g., `\$` and `\\`.
+> When substitution is on, special characters need to be escaped, e.g., `\$` and `\\`.
 >
 > `system` commands don't support the advanced substitution features of the [subst](https://docs.rs/subst/latest/subst/) crate,
 > and excaping is also not needed.

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -78,7 +78,7 @@ pub trait AsyncDB {
 
     /// [`Runner`] calls this function to perform sleep.
     ///
-    /// The default implementation is `std::thread::sleep`, which is universial to any async runtime
+    /// The default implementation is `std::thread::sleep`, which is universal to any async runtime
     /// but would block the current thread. If you are running in tokio runtime, you should override
     /// this by `tokio::time::sleep`.
     async fn sleep(dur: Duration) {
@@ -87,7 +87,7 @@ pub trait AsyncDB {
 
     /// [`Runner`] calls this function to run a system command.
     ///
-    /// The default implementation is `std::process::Command::output`, which is universial to any
+    /// The default implementation is `std::process::Command::output`, which is universal to any
     /// async runtime but would block the current thread. If you are running in tokio runtime, you
     /// should override this by `tokio::process::Command::output`.
     async fn run_command(mut command: Command) -> std::io::Result<std::process::Output> {

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -647,7 +647,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                     cmd.arg("/C").arg(&command);
                     cmd
                 } else {
-                    let mut cmd = std::process::Command::new("sh");
+                    let mut cmd = std::process::Command::new("bash");
                     cmd.arg("-c").arg(&command);
                     cmd
                 };

--- a/tests/system_command/system_command.slt
+++ b/tests/system_command/system_command.slt
@@ -25,7 +25,7 @@ echo "114514"
 
 # Note: 1 blank line in the middle is ok, but not 2
 system ok
-echo "114\n\n514"
+echo $'114\n\n514'
 ----
 114
 


### PR DESCRIPTION
close #217

- no strong motivation to make it configurable yet
- bash's extensions are useful for scripting: arrays, loops, heredoc, etc.
- When the machine's `sh` is actually `bash`, using `sh` to execute will succeed without warnings. This caused a lot of trouble for me (i.e., why it works locally, but not in CI?)