### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,9 +86,7 @@ jobs:
       run: |
         outdir="./target/${{ env.TARGET_DIR }}/release"
         staging="${{ env.CRATE_NAME }}-${{ needs.create-release.outputs.release_version }}-${{ matrix.target }}"
-        mkdir -p "$staging"/{complete,doc}
-        cp {README.md,LICENSE-*} "$staging/"
-        cp {CHANGELOG.md,docs/*} "$staging/doc/"
+        cp {README.md,LICENSE-*,CHANGELOG.md} "$staging/"
         if [ "${{ matrix.os }}" = "windows-2019" ]; then
           cp "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}.exe" "$staging/"
           cd "$staging"


### PR DESCRIPTION
Error:
<img width="522" alt="image" src="https://github.com/risinglightdb/sqllogictest-rs/assets/37948597/fbd76e54-808a-4a11-8e08-b752d0607846">


Previous content:
```
tree ~/Downloads/sqllogictest-bin-v0.20.6-x86_64-unknown-linux-musl/
/Users/xxchan/Downloads/sqllogictest-bin-v0.20.6-x86_64-unknown-linux-musl/
├── LICENSE-APACHE
├── LICENSE-MIT
├── README.md
├── complete
├── doc
│   ├── CHANGELOG.md
│   ├── demo.gif
│   └── demo.tape
└── sqllogictest
```