### PR TITLE
Add valuesort, new control result mode and value normalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.24.0] - 2024-12-20
+
+* runner: Added a `Normalizer` type for normalizing result values. A new function
+  `with_normalizer(normalizer: Normalizer)`
+  has been added to the Runner to allow for specifying a custom Normalizer. The existing default normalizer
+  is available via the `runner::default_normalizer(..)` function.
+* parser: Added a new control mode `resultmode` that controls whether the results are in
+  `valuewise` or `columnwise` mode. The default is `columnwise` which means results are in columns.
+  `valuewise` means the results are in a single column (sqlite test style).
+* parser: Added `valuesort`sort mode. The `valuesort` mode works like rowsort except that it does not
+  honor row groupings. Each individual result value is sorted on its own.
+
+**Breaking change**:
+
+* The `Validator` type used in various function in Runner implementation has a new required field `Normalizer`
+  that is used to normalize result values.
+
 ## [0.23.1] - 2024-12-13
 
 * feat(bin): add opt `--keep-db-on-failure`
@@ -14,9 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.23.0] - 2024-11-16
 
 * Refine the behavior of `update_record_with_output` / `--override`
-  - runner: Previously, `query` returning 0 rows will become `statement ok`. Now it returns `statement count 0`.
-  - bin: Now `--override` will not change the type chars of `query <types>`, since in practice
-    it becomes `?`s which might cause confusion.
+    - runner: Previously, `query` returning 0 rows will become `statement ok`. Now it returns `statement count 0`.
+    - bin: Now `--override` will not change the type chars of `query <types>`, since in practice
+      it becomes `?`s which might cause confusion.
 * runner: `statement count <n>` is incorrectly handled when the result is a `query`.
 
 ## [0.22.1] - 2024-11-11
@@ -30,18 +47,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.21.0] - 2024-06-30
 
 **Breaking changes**:
-* runner: `RecordOutput` is now returned by `Runner::run` (or `Runner::run_async`). This allows users to access the output of each record, or check whether the record is skipped.
-* runner(substitution): add a special variable `__NOW__` which will be replaced with the current Unix timestamp in nanoseconds.
-* runner(substitution): for `system` commands, we do not substitute environment variables any more, because the shell can do that. It's necessary to escape like `\\` any more. `$__TEST_DIR__`, and are still supported.
+
+* runner: `RecordOutput` is now returned by `Runner::run` (or `Runner::run_async`). This allows users to access the
+  output of each record, or check whether the record is skipped.
+* runner(substitution): add a special variable `__NOW__` which will be replaced with the current Unix timestamp in
+  nanoseconds.
+* runner(substitution): for `system` commands, we do not substitute environment variables any more, because the shell
+  can do that. It's necessary to escape like `\\` any more. `$__TEST_DIR__`, and are still supported.
 * runner(system): change `sh` to `bash`.
 
 ## [0.20.6] - 2024-06-21
 
-* runner: add logs for `system` command (with target `sqllogictest::system_command`) for ease of debugging. 
+* runner: add logs for `system` command (with target `sqllogictest::system_command`) for ease of debugging.
 
 ## [0.20.5] - 2024-06-20
 
-* fix(runner): when running in parallel, the runner will correctly inherit configuration like `sort_mode` and `labels` from the main runner.
+* fix(runner): when running in parallel, the runner will correctly inherit configuration like `sort_mode` and `labels`
+  from the main runner.
 
 ## [0.20.4] - 2024-06-06
 
@@ -57,9 +79,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.20.1] - 2024-04-17
 
-* bin: When using `-j <jobs>` to run tests in parallel, add a random suffix to the temporary databases. This is useful if the test is manually canceled, but you want to rerun it freshly. Note that if the test failed, the database will be dropped. This is existing behavior and unchanged.
-* bin: replace `env_logger` with `tracing-subscriber`. You will be able to see the record being executed with `RUST_LOG=debug sqllogictest ...`.
-* runner: fix the behavior of background `system` commands (end with `&`). In `0.20.0`, it will block until the process exits. Now we return immediately.
+* bin: When using `-j <jobs>` to run tests in parallel, add a random suffix to the temporary databases. This is useful
+  if the test is manually canceled, but you want to rerun it freshly. Note that if the test failed, the database will be
+  dropped. This is existing behavior and unchanged.
+* bin: replace `env_logger` with `tracing-subscriber`. You will be able to see the record being executed with
+  `RUST_LOG=debug sqllogictest ...`.
+* runner: fix the behavior of background `system` commands (end with `&`). In `0.20.0`, it will block until the process
+  exits. Now we return immediately.
   ```
   system ok
   sleep 5 &
@@ -75,16 +101,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ----
   Hello, world!
   ```
-  Currently, only exact match is supported. Besides, the output cannot contain more than one blank lines in between. The record ends with two consecutive blank lines.
+  Currently, only exact match is supported. Besides, the output cannot contain more than one blank lines in between. The
+  record ends with two consecutive blank lines.
 
   Some minor **Breaking changes**:
-  - Add field `stdout` to `parser::Record::System` and `runner::RecordOutput::System`, and mark them as `#[non_exhaustive]`.
-  - Change trait method `AsyncDB::run_command`'s return type from `std::process::ExitStatus` to `std::process::Output`.
-
+    - Add field `stdout` to `parser::Record::System` and `runner::RecordOutput::System`, and mark them as
+      `#[non_exhaustive]`.
+    - Change trait method `AsyncDB::run_command`'s return type from `std::process::ExitStatus` to
+      `std::process::Output`.
 
 ## [0.19.1] - 2024-01-04
 
-* parser: `include` now returns error if no file is matched. 
+* parser: `include` now returns error if no file is matched.
 
 ## [0.19.0] - 2023-11-11
 
@@ -104,17 +132,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     2: Division by zero
   ```
 
-  The output error message must be the exact match of the expected one to pass the test, except for the leading and trailing whitespaces. Users may use `--override` to let the runner update the test files with the actual output.
+  The output error message must be the exact match of the expected one to pass the test, except for the leading and
+  trailing whitespaces. Users may use `--override` to let the runner update the test files with the actual output.
 
-  Empty lines are allowed in the expected error message. As a result, the message must end with two consecutive empty lines.
+  Empty lines are allowed in the expected error message. As a result, the message must end with two consecutive empty
+  lines.
 
   Breaking changes in the parser:
-  - Add new variants to `ParseErrorKind`. Mark it as `#[non_exhaustive]`.
-  - Change the type of `expected_error` from `Regex` to `ExpectedError`, which is either a inline `Regex` or multiline `String`.
+    - Add new variants to `ParseErrorKind`. Mark it as `#[non_exhaustive]`.
+    - Change the type of `expected_error` from `Regex` to `ExpectedError`, which is either a inline `Regex` or multiline
+      `String`.
 
 ## [0.17.2] - 2023-11-01
 
-* fix(runner): fix parallel testing db name duplication. Now we use full file path instead of filename as the temporary db name in `run_parallel_async`.
+* fix(runner): fix parallel testing db name duplication. Now we use full file path instead of filename as the temporary
+  db name in `run_parallel_async`.
 
 ## [0.17.1] - 2023-09-20
 
@@ -123,7 +155,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.17.0] - 2023-09-19
 
 * Support environment variables substitution for SQL and system commands.
-  For compatibility, this feature is by default disabled, and can be enabled by adding `control substitution on` to the test file.
+  For compatibility, this feature is by default disabled, and can be enabled by adding `control substitution on` to the
+  test file.
   ```
   control substitution on
 
@@ -138,7 +171,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ...
   ```
 
-  Besides, there's a special variable `$__TEST_DIR__` which is the path to a temporary directory specific to the current test case.
+  Besides, there's a special variable `$__TEST_DIR__` which is the path to a temporary directory specific to the current
+  test case.
   This can be helpful if you need to manipulate some external resources during the test.
   ```
   control substitution on
@@ -151,12 +185,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```
 
   Changes:
-  - (parser) **Breaking change**: Add `Control::Substitution`. Mark `Control` as `#[non_exhaustive]`.
-  - (runner) **Breaking change**: Remove `enable_testdir`. For migration, one should now enable general substitution by the `control` statement and use a dollar-prefixed `$__TEST_DIR__`.
+    - (parser) **Breaking change**: Add `Control::Substitution`. Mark `Control` as `#[non_exhaustive]`.
+    - (runner) **Breaking change**: Remove `enable_testdir`. For migration, one should now enable general substitution
+      by the `control` statement and use a dollar-prefixed `$__TEST_DIR__`.
 
 ## [0.16.0] - 2023-09-15
 
-* Support running external system commands with the syntax below. This is useful for manipulating some external resources during the test.
+* Support running external system commands with the syntax below. This is useful for manipulating some external
+  resources during the test.
   ```
   system ok
   echo "Hello, world!"
@@ -164,14 +200,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The runner will check the exit code of the command, and the output will be ignored. Currently, only `ok` is supported.
 
   Changes:
-  - (parser) **Breaking change**: Add `Record::System`, and corresponding `TestErrorKind` and `RecordOutput`. Mark `TestErrorKind` and `RecordOutput` as `#[non_exhaustive]`.
-  - (runner) Add `run_command` to `AsyncDB` trait. The default implementation will run the command with `std::process::Command::status`. Implementors can override this method to utilize an asynchronous runtime such as `tokio`.
+    - (parser) **Breaking change**: Add `Record::System`, and corresponding `TestErrorKind` and `RecordOutput`. Mark
+      `TestErrorKind` and `RecordOutput` as `#[non_exhaustive]`.
+    - (runner) Add `run_command` to `AsyncDB` trait. The default implementation will run the command with
+      `std::process::Command::status`. Implementors can override this method to utilize an asynchronous runtime such as
+      `tokio`.
 
-* fix(runner): fix database name duplication for parallel tests by using the **full path** of the test file (instead of the file name) as the database name.
+* fix(runner): fix database name duplication for parallel tests by using the **full path** of the test file (instead of
+  the file name) as the database name.
 
 ## [0.15.3] - 2023-08-02
 
-* fix(bin): fix error context display. To avoid stack backtrace being printed, unset `RUST_BACKTRACE` environment variable, or use pre-built binaries built with stable toolchain instead.
+* fix(bin): fix error context display. To avoid stack backtrace being printed, unset `RUST_BACKTRACE` environment
+  variable, or use pre-built binaries built with stable toolchain instead.
 
 ## [0.15.2] - 2023-07-31
 
@@ -179,21 +220,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.15.1] - 2023-07-24
 
-* fix `statement error` unexpectedly passed when result is a successful `query`. Similarly for expected `query error` but successful `statement ok`.
+* fix `statement error` unexpectedly passed when result is a successful `query`. Similarly for expected `query error`
+  but successful `statement ok`.
 
 ## [0.15.0] - 2023-07-06
 
-* Allow multiple connections to the database in a single test case, which is useful for testing the transaction behavior. This can be achieved by attaching a `connection foo` record before the query or statement.
-  - (parser) Add `Record::Connection`.
-  - (runner) **Breaking change**: Since the runner may establish multiple connections at runtime, `Runner::new` now takes a `impl MakeConnection`, which is usually a closure that returns a try-future of the `AsyncDB` instance.
-  - (bin) The connection to the database is now established lazily on the first query or statement.
+* Allow multiple connections to the database in a single test case, which is useful for testing the transaction
+  behavior. This can be achieved by attaching a `connection foo` record before the query or statement.
+    - (parser) Add `Record::Connection`.
+    - (runner) **Breaking change**: Since the runner may establish multiple connections at runtime, `Runner::new` now
+      takes a `impl MakeConnection`, which is usually a closure that returns a try-future of the `AsyncDB` instance.
+    - (bin) The connection to the database is now established lazily on the first query or statement.
 
 ## [0.14.0] - 2023-06-08
 
-* We enhanced how `skipif` and `onlyif` works. Previously it checks against `DB::engine_name()`, and `sqllogictest-bin` didn't implement it.
-  - (parser) A minor **breaking change**: Change the field names of `Condition:: OnlyIf/SkipIf`.
-  - (runner) Add `Runner::add_label`. Now multiple labels are supported ( `DB::engine_name()` is still included). The condition evaluates to true if *any* of the provided labels match the `skipif/onlyif <label>`.
-  - (bin) Add `--label` option to specify custom labels.
+* We enhanced how `skipif` and `onlyif` works. Previously it checks against `DB::engine_name()`, and `sqllogictest-bin`
+  didn't implement it.
+    - (parser) A minor **breaking change**: Change the field names of `Condition:: OnlyIf/SkipIf`.
+    - (runner) Add `Runner::add_label`. Now multiple labels are supported ( `DB::engine_name()` is still included). The
+      condition evaluates to true if *any* of the provided labels match the `skipif/onlyif <label>`.
+    - (bin) Add `--label` option to specify custom labels.
 
 ## [0.13.2] - 2023-03-24
 
@@ -232,15 +278,17 @@ This release contains some minor fixes.
 
 ## [0.10.0] - 2022-12-15
 
-- Improve the ability to unparse and update the test files. Mainly add `update_record_with_output` and `update_test_file` to the library. 
+- Improve the ability to unparse and update the test files. Mainly add `update_record_with_output` and
+  `update_test_file` to the library.
 
   More details:
-  * Add `impl Display` for `Record` (refactor `unparse`).
-  * Add `Record::Whitespace` so the whitespace in the original files can be reconstructed during `unparse`.
-  * Add tests for unparsing and updating records.
-  * Refactor and fix the behavior about newlines and `halt` for CLI options `--override` and `--format`.
+    * Add `impl Display` for `Record` (refactor `unparse`).
+    * Add `Record::Whitespace` so the whitespace in the original files can be reconstructed during `unparse`.
+    * Add tests for unparsing and updating records.
+    * Refactor and fix the behavior about newlines and `halt` for CLI options `--override` and `--format`.
 - Fix: `hash-threshold` should be compared with the number of values instead of the number of rows.
-- **Breaking change**: The type of `Validator` is changed from `fn(&Vec<String>, &Vec<String>) -> bool` to `fn(&[Vec<String>], &[String]) -> bool`. Also added a `default_validator`.
+- **Breaking change**: The type of `Validator` is changed from `fn(&Vec<String>, &Vec<String>) -> bool` to
+  `fn(&[Vec<String>], &[String]) -> bool`. Also added a `default_validator`.
 
 Thanks to the contributions of @alamb and @xudong963 .
 
@@ -249,19 +297,22 @@ Thanks to the contributions of @alamb and @xudong963 .
 - Improve the format and color handling for errors.
 - Support `hash-threshold`.
 - Fix `statement count <n>` for postgres engines.
-- **Breaking change**: use `Vec<Vec<String>>` instead of `String` as the query results by `DB`. This allows the runner to verify the results more precisely.
-  + For `rowsort`, runner will only sort actual results now, which means the result in the test cases should be sorted.
+- **Breaking change**: use `Vec<Vec<String>>` instead of `String` as the query results by `DB`. This allows the runner
+  to verify the results more precisely.
+    + For `rowsort`, runner will only sort actual results now, which means the result in the test cases should be
+      sorted.
 - **Breaking change**: `Hook` is removed.
 - **Breaking change**: `Record` and parser's behavior are tweaked:
-  + retain `Include` record when linking its content
-  + keep parsing after `Halt`
-  + move `Begin/EndInclude` to `Injected`
-- Added CLI options `--override` and `--format`, which can override the test files with the actual output of the database, or reformat the test files.
+    + retain `Include` record when linking its content
+    + keep parsing after `Halt`
+    + move `Begin/EndInclude` to `Injected`
+- Added CLI options `--override` and `--format`, which can override the test files with the actual output of the
+  database, or reformat the test files.
 
 ## [0.8.0] - 2022-11-22
 
 - Support checking error message using `statement error <regex>` and `query error <regex>` syntax.
-  - **Breaking change**: `Record::Statement`,  `Record::Query` and `TestErrorKind` are changed accordingly.
+    - **Breaking change**: `Record::Statement`,  `Record::Query` and `TestErrorKind` are changed accordingly.
 
 ## [0.7.1] - 2022-11-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "educe",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-bin"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1935,7 +1935,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-engines"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "arrayvec"
@@ -127,7 +127,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -165,9 +165,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -178,7 +178,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -228,7 +228,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -276,15 +276,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
 dependencies = [
  "jobserver",
  "libc",
@@ -314,9 +314,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -368,20 +368,20 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
 dependencies = [
  "cc",
 ]
@@ -413,9 +413,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -444,18 +444,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -472,18 +472,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -520,7 +520,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -532,7 +532,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -564,7 +564,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -575,12 +575,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -597,9 +597,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flate2"
@@ -704,7 +704,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -781,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -795,12 +795,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hmac"
@@ -955,7 +949,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -981,12 +975,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1006,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jobserver"
@@ -1021,10 +1015,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1045,15 +1040,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.162"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets",
@@ -1090,9 +1085,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -1116,7 +1111,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1161,11 +1156,10 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -1402,7 +1396,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1432,7 +1426,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1496,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1531,24 +1525,24 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-junit"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ffd2f9a162cfae131bed6d9d1ed60adced33be340a94f96952897d7cb0c240"
+checksum = "3ed1a693391a16317257103ad06a88c6529ac640846021da7c435a06fffdacd7"
 dependencies = [
  "chrono",
  "indexmap",
  "newtype-uuid",
  "quick-xml",
  "strip-ansi-escapes",
- "thiserror 1.0.69",
+ "thiserror 2.0.7",
  "uuid",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "f22f29bdff3987b4d8632ef95fd6424ec7e4e0a57e2f4fc63e489e75357f6a03"
 dependencies = [
  "memchr",
 ]
@@ -1600,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
 ]
@@ -1714,21 +1708,21 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustix"
-version = "0.38.40"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1769,29 +1763,29 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",
@@ -1880,9 +1874,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1890,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "educe",
@@ -1907,13 +1901,13 @@ dependencies = [
  "similar",
  "subst",
  "tempfile",
- "thiserror 2.0.3",
+ "thiserror 2.0.7",
  "tracing",
 ]
 
 [[package]]
 name = "sqllogictest-bin"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1935,7 +1929,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-engines"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1949,7 +1943,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqllogictest",
- "thiserror 2.0.3",
+ "thiserror 2.0.7",
  "tokio",
  "tokio-postgres",
  "tokio-util",
@@ -2005,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "subst"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3c1ba4fd019bc866333a61fe205fc9b686e3cf5971dd8dfc116657d933031c"
+checksum = "33e7942675ea19db01ef8cf15a1e6443007208e6c74568bd64162da26d40160d"
 dependencies = [
  "memchr",
  "unicode-width",
@@ -2032,9 +2026,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2049,7 +2043,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2091,11 +2085,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "93605438cbd668185516ab499d589afb7ee1859ea3d5fc8f6b0755e1c7443767"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.7",
 ]
 
 [[package]]
@@ -2106,18 +2100,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "e1d8749b4531af2117677a5fcd12b1348a3fe2b81e36e61ffeac5c4aa3273e36"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2157,9 +2151,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2180,7 +2174,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2211,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2241,9 +2235,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2252,20 +2246,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2284,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2325,9 +2319,9 @@ checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-normalization"
@@ -2352,9 +2346,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2446,9 +2440,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2457,24 +2451,23 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2482,28 +2475,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2671,9 +2664,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -2683,13 +2676,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
  "synstructure",
 ]
 
@@ -2711,27 +2704,27 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
  "synstructure",
 ]
 
@@ -2754,7 +2747,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["sqllogictest", "sqllogictest-bin", "sqllogictest-engines", "tests"]
 
 [workspace.package]
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 homepage = "https://github.com/risinglightdb/sqllogictest-rs"
 keywords = ["sql", "database", "parser", "cli"]

--- a/sqllogictest-bin/Cargo.toml
+++ b/sqllogictest-bin/Cargo.toml
@@ -23,8 +23,8 @@ glob = "0.3"
 itertools = "0.13"
 quick-junit = { version = "0.5" }
 rand = "0.8"
-sqllogictest = { path = "../sqllogictest", version = "0.23" }
-sqllogictest-engines = { path = "../sqllogictest-engines", version = "0.23" }
+sqllogictest = { path = "../sqllogictest", version = "0.24" }
+sqllogictest-engines = { path = "../sqllogictest-engines", version = "0.24" }
 tokio = { version = "1", features = [
     "rt",
     "rt-multi-thread",

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -16,10 +16,7 @@ use itertools::Itertools;
 use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite};
 use rand::distributions::DistString;
 use rand::seq::SliceRandom;
-use sqllogictest::{
-    default_column_validator, default_validator, update_record_with_output, AsyncDB, Injected,
-    MakeConnection, Record, Runner,
-};
+use sqllogictest::{default_column_validator, default_normalizer, default_validator, update_record_with_output, AsyncDB, Injected, MakeConnection, Record, Runner};
 
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 #[must_use]
@@ -750,6 +747,7 @@ async fn update_record<M: MakeConnection>(
         &record_output,
         "\t",
         default_validator,
+        default_normalizer,
         default_column_validator,
     ) {
         Some(new_record) => {

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -16,7 +16,10 @@ use itertools::Itertools;
 use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite};
 use rand::distributions::DistString;
 use rand::seq::SliceRandom;
-use sqllogictest::{default_column_validator, default_normalizer, default_validator, update_record_with_output, AsyncDB, Injected, MakeConnection, Record, Runner};
+use sqllogictest::{
+    default_column_validator, default_normalizer, default_validator, update_record_with_output,
+    AsyncDB, Injected, MakeConnection, Record, Runner,
+};
 
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 #[must_use]

--- a/sqllogictest-engines/Cargo.toml
+++ b/sqllogictest-engines/Cargo.toml
@@ -20,7 +20,7 @@ postgres-types = { version = "0.2.8", features = ["derive", "with-chrono-0_4"] }
 rust_decimal = { version = "1.36.0", features = ["tokio-pg"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqllogictest = { path = "../sqllogictest", version = "0.23" }
+sqllogictest = { path = "../sqllogictest", version = "0.24" }
 thiserror = "2"
 tokio = { version = "1", features = [
     "rt",

--- a/sqllogictest/src/parser.rs
+++ b/sqllogictest/src/parser.rs
@@ -85,6 +85,7 @@ pub enum QueryExpect<T: ColumnType> {
     Results {
         types: Vec<T>,
         sort_mode: Option<SortMode>,
+        result_mode: Option<ResultMode>,
         label: Option<String>,
         results: Vec<String>,
     },
@@ -98,6 +99,7 @@ impl<T: ColumnType> QueryExpect<T> {
         Self::Results {
             types: Vec::new(),
             sort_mode: None,
+            result_mode: None,
             label: None,
             results: Vec::new(),
         }
@@ -287,6 +289,7 @@ impl<T: ColumnType> std::fmt::Display for Record<T> {
             }
             Record::Control(c) => match c {
                 Control::SortMode(m) => write!(f, "control sortmode {}", m.as_str()),
+                Control::ResultMode(m) => write!(f, "control resultmode {}", m.as_str()),
                 Control::Substitution(s) => write!(f, "control substitution {}", s.as_str()),
             },
             Record::Condition(cond) => match cond {
@@ -435,6 +438,8 @@ impl PartialEq for ExpectedError {
 pub enum Control {
     /// Control sort mode.
     SortMode(SortMode),
+    /// control result mode.
+    ResultMode(ResultMode),
     /// Control whether or not to substitute variables in the SQL.
     Substitution(bool),
 }
@@ -542,6 +547,38 @@ impl ControlItem for SortMode {
             Self::RowSort => "rowsort",
             Self::ValueSort => "valuesort",
         }
+    }
+}
+
+/// Whether the results should be parsed as value-wise or row-wise
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ResultMode {
+    /// Results are in a single column
+    ValueWise,
+    /// The default option where results are in columns separated by spaces
+    RowWise,
+}
+
+impl ControlItem for ResultMode {
+    fn try_from_str(s: &str) -> Result<Self, ParseErrorKind> {
+        match s {
+            "rowwise" => Ok(Self::RowWise),
+            "valuewise" => Ok(Self::ValueWise),
+            _ => Err(ParseErrorKind::InvalidSortMode(s.to_string())),
+        }
+    }
+
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::RowWise => "rowwise",
+            Self::ValueWise => "valuewise",
+        }
+    }
+}
+
+impl fmt::Display for ResultMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
     }
 }
 
@@ -754,6 +791,7 @@ fn parse_inner<T: ColumnType>(loc: &Location, script: &str) -> Result<Vec<Record
                         QueryExpect::Results {
                             types,
                             sort_mode,
+                            result_mode: None,
                             label,
                             results: Vec::new(),
                         }
@@ -812,6 +850,10 @@ fn parse_inner<T: ColumnType>(loc: &Location, script: &str) -> Result<Vec<Record
                 });
             }
             ["control", res @ ..] => match res {
+                ["resultmode", result_mode] =>  match ResultMode::try_from_str(result_mode) {
+                    Ok(result_mode) => records.push(Record::Control(Control::ResultMode(result_mode))),
+                    Err(k) => return Err(k.at(loc)),
+                },
                 ["sortmode", sort_mode] => match SortMode::try_from_str(sort_mode) {
                     Ok(sort_mode) => records.push(Record::Control(Control::SortMode(sort_mode))),
                     Err(k) => return Err(k.at(loc)),
@@ -829,7 +871,7 @@ fn parse_inner<T: ColumnType>(loc: &Location, script: &str) -> Result<Vec<Record
                         ParseErrorKind::InvalidNumber((*threshold).into()).at(loc.clone())
                     })?,
                 });
-            }
+            },
             _ => return Err(ParseErrorKind::InvalidLine(line.into()).at(loc)),
         }
     }

--- a/sqllogictest/src/parser.rs
+++ b/sqllogictest/src/parser.rs
@@ -1033,6 +1033,11 @@ mod tests {
     }
 
     #[test]
+    fn test_valuesort() {
+        parse_roundtrip::<DefaultColumnType>("../tests/slt/valuesort.slt")
+    }
+
+    #[test]
     fn test_substitution() {
         parse_roundtrip::<DefaultColumnType>("../tests/substitution/basic.slt")
     }

--- a/sqllogictest/src/parser.rs
+++ b/sqllogictest/src/parser.rs
@@ -850,8 +850,10 @@ fn parse_inner<T: ColumnType>(loc: &Location, script: &str) -> Result<Vec<Record
                 });
             }
             ["control", res @ ..] => match res {
-                ["resultmode", result_mode] =>  match ResultMode::try_from_str(result_mode) {
-                    Ok(result_mode) => records.push(Record::Control(Control::ResultMode(result_mode))),
+                ["resultmode", result_mode] => match ResultMode::try_from_str(result_mode) {
+                    Ok(result_mode) => {
+                        records.push(Record::Control(Control::ResultMode(result_mode)))
+                    }
                     Err(k) => return Err(k.at(loc)),
                 },
                 ["sortmode", sort_mode] => match SortMode::try_from_str(sort_mode) {
@@ -871,7 +873,7 @@ fn parse_inner<T: ColumnType>(loc: &Location, script: &str) -> Result<Vec<Record
                         ParseErrorKind::InvalidNumber((*threshold).into()).at(loc.clone())
                     })?,
                 });
-            },
+            }
             _ => return Err(ParseErrorKind::InvalidLine(line.into()).at(loc)),
         }
     }

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -1038,8 +1038,8 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
 
                         let actual_results = match self.result_mode {
                             Some(ResultMode::ValueWise) => rows
-                                .into_iter()
-                                .flat_map(|strs| strs.into_iter())
+                                .iter()
+                                .flat_map(|strs| strs.iter())
                                 .map(|str| vec![str.to_string()])
                                 .collect_vec(),
                             // default to rowwise

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -467,9 +467,14 @@ pub fn default_normalizer(s: &String) -> String {
 /// # Default
 ///
 /// By default, the ([`default_validator`]) will be used compare normalized results.
-pub type Validator = fn(normalizer: Normalizer, actual: &[Vec<String>], expected: &[String]) -> bool;
+pub type Validator =
+    fn(normalizer: Normalizer, actual: &[Vec<String>], expected: &[String]) -> bool;
 
-pub fn default_validator(normalizer: Normalizer, actual: &[Vec<String>], expected: &[String]) -> bool {
+pub fn default_validator(
+    normalizer: Normalizer,
+    actual: &[Vec<String>],
+    expected: &[String],
+) -> bool {
     let expected_results = expected.iter().map(normalizer).collect_vec();
     // Default, we compare normalized results. Whitespace characters are ignored.
     let normalized_rows = actual
@@ -1032,11 +1037,11 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                         }
 
                         let actual_results = match self.result_mode {
-                            Some(ResultMode::ValueWise) =>
-                                rows.into_iter()
-                                    .flat_map(|strs| strs.into_iter())
-                                    .map(|str| vec![str.to_string()])
-                                    .collect_vec(),
+                            Some(ResultMode::ValueWise) => rows
+                                .into_iter()
+                                .flat_map(|strs| strs.into_iter())
+                                .map(|str| vec![str.to_string()])
+                                .collect_vec(),
                             // default to rowwise
                             _ => rows.clone(),
                         };
@@ -1591,7 +1596,10 @@ pub fn update_record_with_output<T: ColumnType>(
                     connection,
                     expected: match expected {
                         QueryExpect::Results {
-                            sort_mode, label, result_mode, ..
+                            sort_mode,
+                            label,
+                            result_mode,
+                            ..
                         } => QueryExpect::Results {
                             results,
                             types,

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -154,7 +154,7 @@ pub struct TestErrorDisplay<'a> {
     colorize: bool,
 }
 
-impl<'a> Display for TestErrorDisplay<'a> {
+impl Display for TestErrorDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -189,7 +189,7 @@ pub struct ParallelTestErrorDisplay<'a> {
     colorize: bool,
 }
 
-impl<'a> Display for ParallelTestErrorDisplay<'a> {
+impl Display for ParallelTestErrorDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "parallel test failed")?;
         write!(f, "Caused by:")?;
@@ -332,7 +332,7 @@ pub struct TestErrorKindDisplay<'a> {
     colorize: bool,
 }
 
-impl<'a> Display for TestErrorKindDisplay<'a> {
+impl Display for TestErrorKindDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if !self.colorize {
             return write!(f, "{}", self.error);

--- a/tests/custom_type/custom_type.rs
+++ b/tests/custom_type/custom_type.rs
@@ -69,5 +69,8 @@ fn test() {
     let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB) });
     tester.with_column_validator(strict_column_validator);
 
-    tester.run_file("./custom_type/custom_type.slt").unwrap();
+    let r = tester.run_file("./custom_type/custom_type.slt");
+    if let Err(err) = r {
+        eprintln!("{:?}", err);
+    }
 }

--- a/tests/slt/rowsort.slt
+++ b/tests/slt/rowsort.slt
@@ -1,10 +1,3 @@
-query III rowsort
-select * from example_sort
-----
-1 10 2333
-10 100 2333
-2 20 2333
-
 control resultmode valuewise
 
 query III rowsort
@@ -19,3 +12,12 @@ select * from example_sort
 2
 20
 2333
+
+control resultmode rowwise
+
+query III rowsort
+select * from example_sort
+----
+1 10 2333
+10 100 2333
+2 20 2333

--- a/tests/slt/rowsort.slt
+++ b/tests/slt/rowsort.slt
@@ -4,3 +4,18 @@ select * from example_sort
 1 10 2333
 10 100 2333
 2 20 2333
+
+control resultmode valuewise
+
+query III rowsort
+select * from example_sort
+----
+1
+10
+2333
+10
+100
+2333
+2
+20
+2333

--- a/tests/slt/valuesort.slt
+++ b/tests/slt/valuesort.slt
@@ -1,0 +1,28 @@
+query III valuesort
+select * from example_sort
+----
+1
+10
+10
+100
+2
+20
+2333
+2333
+2333
+
+control resultmode rowwise
+
+# value sort is always single column
+query III valuesort
+select * from example_sort
+----
+1
+10
+10
+100
+2
+20
+2333
+2333
+2333

--- a/tests/validator/validator.rs
+++ b/tests/validator/validator.rs
@@ -29,7 +29,7 @@ impl sqllogictest::DB for FakeDB {
 fn test() {
     let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB) });
     // Validator will always return true.
-    tester.with_validator(|_, _| true);
+    tester.with_validator(|_, _, _| true);
 
     tester.run_file("./validator/validator.slt").unwrap();
 }


### PR DESCRIPTION
I've adding some functionality to support running the sqlite test suite against another database and this PR is the initial part of that work. This PR adds:

- valuesort from PR #123 
- a new control `resultmode` of either `valuewise` or `rowwise` (defaulting to the latter)
- a new value normalizer to allow for different value normalization for different files

The last point is a breaking API change so I took the liberty to rev the version #. If that isn't desired feel free to revert that portion of this PR.

With this PR I am able to run a slightly cleansed sqlite test suite using the Datafusion sqllogictest harness.