### PR TITLE
feat: support retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.25.0] - 2024-12-26
+
+* runner: Add `retry` clause to `statement ok` and `query ok|error`.
+
 ## [0.24.0] - 2024-12-20
 
 * runner: Added a `Normalizer` type for normalizing result values. A new function

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "educe",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-bin"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1929,7 +1929,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-engines"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["sqllogictest", "sqllogictest-bin", "sqllogictest-engines", "tests"]
 
 [workspace.package]
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 homepage = "https://github.com/risinglightdb/sqllogictest-rs"
 keywords = ["sql", "database", "parser", "cli"]

--- a/README.md
+++ b/README.md
@@ -132,6 +132,18 @@ echo $USER
 xxchan
 ```
 
+### Extension: Retry
+
+```text
+query I retry 3 backoff 5s
+SELECT id FROM test;
+----
+1
+
+statement ok retry 3 backoff 5s
+UPDATE test SET id = 1;
+```
+
 ### Extension: Environment variable substitution in query and statement
 
 It needs to be enabled by adding `control substitution on` to the test file.

--- a/sqllogictest-bin/Cargo.toml
+++ b/sqllogictest-bin/Cargo.toml
@@ -23,8 +23,8 @@ glob = "0.3"
 itertools = "0.13"
 quick-junit = { version = "0.5" }
 rand = "0.8"
-sqllogictest = { path = "../sqllogictest", version = "0.24" }
-sqllogictest-engines = { path = "../sqllogictest-engines", version = "0.24" }
+sqllogictest = { path = "../sqllogictest", version = "0.25" }
+sqllogictest-engines = { path = "../sqllogictest-engines", version = "0.25" }
 tokio = { version = "1", features = [
     "rt",
     "rt-multi-thread",

--- a/sqllogictest-engines/Cargo.toml
+++ b/sqllogictest-engines/Cargo.toml
@@ -20,7 +20,7 @@ postgres-types = { version = "0.2.8", features = ["derive", "with-chrono-0_4"] }
 rust_decimal = { version = "1.36.0", features = ["tokio-pg"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqllogictest = { path = "../sqllogictest", version = "0.24" }
+sqllogictest = { path = "../sqllogictest", version = "0.25" }
 thiserror = "2"
 tokio = { version = "1", features = [
     "rt",

--- a/tests/retry/query_retry.slt
+++ b/tests/retry/query_retry.slt
@@ -1,0 +1,16 @@
+query I retry 3 backoff 5s
+SELECT id FROM test;
+----
+1
+
+query I rowsort retry 2 backoff 1s
+SELECT id FROM test ORDER BY random();
+----
+1
+2
+3
+
+query I retry 1 backoff 500ms
+SELECT id FROM test;
+----
+1 

--- a/tests/retry/statement_retry.slt
+++ b/tests/retry/statement_retry.slt
@@ -1,0 +1,5 @@
+statement ok retry 3 backoff 5s
+INSERT INTO test VALUES (1);
+
+statement count 5 retry 2 backoff 1s
+UPDATE test SET value = value + 1; 


### PR DESCRIPTION
Resolves https://github.com/risinglightdb/sqllogictest-rs/issues/238.

Also removed `label` from `QueryExpect::Results` because it's never used.