### PR TITLE
feat: support retry for `[statement|query] error`

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ SELECT id FROM test;
 ----
 database error: table not found
 
+
 statement ok retry 3 backoff 5s
 UPDATE test SET id = 1;
 

--- a/README.md
+++ b/README.md
@@ -140,9 +140,21 @@ SELECT id FROM test;
 ----
 1
 
+query error retry 3 backoff 5s
+SELECT id FROM test;
+----
+database error: table not found
+
 statement ok retry 3 backoff 5s
 UPDATE test SET id = 1;
+
+statement error
+UPDATE test SET value = value + 1; 
+----
+database error: table not found
 ```
+
+Due to the limitation of syntax, the retry clause can't be used along with the single-line regex error message extension.
 
 ### Extension: Environment variable substitution in query and statement
 

--- a/tests/retry/query_retry.slt
+++ b/tests/retry/query_retry.slt
@@ -10,7 +10,17 @@ SELECT id FROM test ORDER BY random();
 2
 3
 
-query I retry 1 backoff 500ms
+query I retry 2 backoff 500ms
 SELECT id FROM test;
 ----
 1 
+
+query error retry 2 backoff 500ms
+SELECT id FROM test;
+----
+table not found
+
+query error
+SELECT id FROM test;
+----
+table not found

--- a/tests/retry/query_retry.slt
+++ b/tests/retry/query_retry.slt
@@ -20,7 +20,9 @@ SELECT id FROM test;
 ----
 table not found
 
+
 query error
 SELECT id FROM test;
 ----
 table not found
+

--- a/tests/retry/statement_retry.slt
+++ b/tests/retry/statement_retry.slt
@@ -9,7 +9,9 @@ UPDATE test SET value = value + 1;
 ----
 table not found
 
+
 statement error
 UPDATE test SET value = value + 1; 
 ----
 table not found
+

--- a/tests/retry/statement_retry.slt
+++ b/tests/retry/statement_retry.slt
@@ -3,3 +3,13 @@ INSERT INTO test VALUES (1);
 
 statement count 5 retry 2 backoff 1s
 UPDATE test SET value = value + 1; 
+
+statement error retry 2 backoff 500ms
+UPDATE test SET value = value + 1; 
+----
+table not found
+
+statement error
+UPDATE test SET value = value + 1; 
+----
+table not found


### PR DESCRIPTION
Previous PR #239 doesn't support `retry` for error query or statement. This is because any tokens after the `[statement|query] error` are treated as error message regex.

However, we found this case is useful. https://github.com/risinglightdb/sqllogictest-rs/pull/239#discussion_r1901548064

This PR adds support for `[statement|query] error` with multiline message. As a compromise, the single-line syntax `[statement|query] error <error message regex...>` is not supported.