### PR TITLE
feat(bin): abort connections before dropping temp databases in parallel run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.26.3] - 2025-01-14
+
+* bin: when `--fail-fast` is enabled, abort all remaining connections before dropping temporary databases.
+
 ## [0.26.2] - 2025-01-08
 
 * bin: support `--fail-fast`, and add env vars `SLT_FAIL_FAST` and `SLT_KEEP_DB_ON_FAILURE`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -1923,6 +1929,7 @@ dependencies = [
  "sqllogictest",
  "sqllogictest-engines",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2212,6 +2219,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.14.5",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "async-trait",
  "educe",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-bin"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-engines"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["sqllogictest", "sqllogictest-bin", "sqllogictest-engines", "tests"]
 
 [workspace.package]
-version = "0.26.2"
+version = "0.26.3"
 edition = "2021"
 homepage = "https://github.com/risinglightdb/sqllogictest-rs"
 keywords = ["sql", "database", "parser", "cli"]

--- a/sqllogictest-bin/Cargo.toml
+++ b/sqllogictest-bin/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { version = "1", features = [
     "fs",
     "process",
 ] }
+tokio-util = { version = "0.7.12", features = ["rt"] }
 fs-err = "3.0.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = "0.1"

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -837,11 +837,9 @@ async fn update_record<M: MakeConnection>(
 }
 
 mod utils {
-    use std::{
-        future::Future,
-        pin::Pin,
-        task::{Context, Poll},
-    };
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
 
     use tokio::task::{JoinError, JoinHandle};
 

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -20,7 +20,7 @@ use sqllogictest::{
     default_column_validator, default_normalizer, default_validator, update_record_with_output,
     AsyncDB, Injected, MakeConnection, Record, Runner,
 };
-use utils::AbortOnDropHandle;
+use tokio_util::task::AbortOnDropHandle;
 
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 #[must_use]
@@ -323,7 +323,7 @@ async fn run_parallel(
             let engine = engine.clone();
             let labels = labels.to_vec();
             async move {
-                let (buf, res) = AbortOnDropHandle(tokio::spawn(async move {
+                let (buf, res) = AbortOnDropHandle::new(tokio::spawn(async move {
                     let mut buf = vec![];
                     let res =
                         connect_and_run_test_file(&mut buf, filename, &engine, config, &labels)
@@ -834,29 +834,4 @@ async fn update_record<M: MakeConnection>(
     }
 
     Ok(())
-}
-
-mod utils {
-    use std::future::Future;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
-
-    use tokio::task::{JoinError, JoinHandle};
-
-    /// A wrapper around a [`tokio::task::JoinHandle`], which aborts the task when it is dropped.
-    pub struct AbortOnDropHandle<T>(pub JoinHandle<T>);
-
-    impl<T> Drop for AbortOnDropHandle<T> {
-        fn drop(&mut self) {
-            self.0.abort();
-        }
-    }
-
-    impl<T> Future for AbortOnDropHandle<T> {
-        type Output = Result<T, JoinError>;
-
-        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-            Pin::new(&mut self.0).poll(cx)
-        }
-    }
 }

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -397,8 +397,8 @@ async fn run_parallel(
         start.elapsed().as_millis()
     );
 
-    // Abort running cases and drop the session connections to the DB server
-    // before dropping temporary databases.
+    // If `fail_fast`, there could be some ongoing cases (then active connections)
+    // in the stream. Abort them before dropping temporary databases.
     drop(stream);
 
     for db_name in db_names {


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

Improvement to https://github.com/risinglightdb/sqllogictest-rs/pull/246.