### PR TITLE
Add random string in path generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1903,6 +1903,7 @@ dependencies = [
  "md-5",
  "owo-colors",
  "pretty_assertions",
+ "rand",
  "regex",
  "similar",
  "subst",

--- a/sqllogictest/Cargo.toml
+++ b/sqllogictest/Cargo.toml
@@ -25,6 +25,7 @@ subst = "0.3"
 tempfile = "3"
 thiserror = "2"
 tracing = "0.1"
+rand = "0.8.5"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -14,6 +14,7 @@ use futures::{stream, Future, FutureExt, StreamExt};
 use itertools::Itertools;
 use md5::Digest;
 use owo_colors::OwoColorize;
+use rand::Rng;
 use similar::{Change, ChangeTag, TextDiff};
 
 use crate::parser::*;
@@ -1339,7 +1340,12 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
 
         fn create_outfile(filename: impl AsRef<Path>) -> std::io::Result<(PathBuf, File)> {
             let filename = filename.as_ref();
-            let outfilename = filename.file_name().unwrap().to_str().unwrap().to_owned() + ".temp";
+            let outfilename = format!(
+                "{}{:010}{}",
+                filename.file_name().unwrap().to_str().unwrap().to_owned(),
+                rand::thread_rng().gen_range(0..10_000_000),
+                ".temp"
+            );
             let outfilename = filename.parent().unwrap().join(outfilename);
             // create a temp file in read-write mode
             let outfile = OpenOptions::new()


### PR DESCRIPTION
We encountered an error while running sqllogictest in datafusion.
https://github.com/apache/datafusion/issues/12752
https://github.com/apache/datafusion/pull/14254

This happens when multiple .slt file include from a single parent file while running on multiple threads.
This result in creation of multiple temp file(for parent file) and subsequent failure as these temp files are removed by one thread and then other tries to remove/access it too.

A simple solution is to add a random string to `outfilename` as done in this PR.