### PR TITLE
feat: add `shutdown` method to `AsyncDB` `DB` and `Runner`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.27.0] - 2025-02-11
+
+* runner: add `shutdown` method to `DB` and `AsyncDB` trait to allow for graceful shutdown of the database connection. Users are encouraged to call `Runner::shutdown` or `Runner::shutdown_async` after running tests to ensure that the database connections are properly closed.
+
 ## [0.26.4] - 2025-01-27
 
 * runner: add random string in path generation to avoid conflict when using `include`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest"
-version = "0.26.4"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "educe",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-bin"
-version = "0.26.4"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-engines"
-version = "0.26.4"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["sqllogictest", "sqllogictest-bin", "sqllogictest-engines", "tests"]
 
 [workspace.package]
-version = "0.26.4"
+version = "0.27.0"
 edition = "2021"
 homepage = "https://github.com/risinglightdb/sqllogictest-rs"
 keywords = ["sql", "database", "parser", "cli"]

--- a/sqllogictest-bin/Cargo.toml
+++ b/sqllogictest-bin/Cargo.toml
@@ -23,8 +23,8 @@ glob = "0.3"
 itertools = "0.13"
 quick-junit = { version = "0.5" }
 rand = "0.8"
-sqllogictest = { path = "../sqllogictest", version = "0.26" }
-sqllogictest-engines = { path = "../sqllogictest-engines", version = "0.26" }
+sqllogictest = { path = "../sqllogictest", version = "0.27" }
+sqllogictest-engines = { path = "../sqllogictest-engines", version = "0.27" }
 tokio = { version = "1", features = [
     "rt",
     "rt-multi-thread",

--- a/sqllogictest-bin/src/engines.rs
+++ b/sqllogictest-bin/src/engines.rs
@@ -154,4 +154,8 @@ impl AsyncDB for Engines {
     async fn run_command(command: std::process::Command) -> std::io::Result<std::process::Output> {
         Command::from(command).output().await
     }
+
+    async fn shutdown(&mut self) {
+        dispatch_engines!(self, e, { e.shutdown().await })
+    }
 }

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -437,6 +437,9 @@ async fn run_parallel(
         }
     }
 
+    // Shutdown the connection for managing temporary databases.
+    db.shutdown().await;
+
     if !failed_case.is_empty() {
         Err(anyhow!("some test case failed:\n{:#?}", failed_case))
     } else {

--- a/sqllogictest-engines/Cargo.toml
+++ b/sqllogictest-engines/Cargo.toml
@@ -20,7 +20,7 @@ postgres-types = { version = "0.2.8", features = ["derive", "with-chrono-0_4"] }
 rust_decimal = { version = "1.36.0", features = ["tokio-pg"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqllogictest = { path = "../sqllogictest", version = "0.26" }
+sqllogictest = { path = "../sqllogictest", version = "0.27" }
 thiserror = "2"
 tokio = { version = "1", features = [
     "rt",

--- a/sqllogictest-engines/src/external.rs
+++ b/sqllogictest-engines/src/external.rs
@@ -113,6 +113,11 @@ impl AsyncDB for ExternalDriver {
         }
     }
 
+    async fn shutdown(&mut self) {
+        self.stdin.shutdown().await.ok();
+        self.child.wait().await.ok();
+    }
+
     fn engine_name(&self) -> &str {
         "external"
     }

--- a/sqllogictest-engines/src/mysql.rs
+++ b/sqllogictest-engines/src/mysql.rs
@@ -66,6 +66,10 @@ impl sqllogictest::AsyncDB for MySql {
         }
     }
 
+    async fn shutdown(&mut self) {
+        self.pool.clone().disconnect().await.ok();
+    }
+
     fn engine_name(&self) -> &str {
         "mysql"
     }

--- a/sqllogictest-engines/src/postgres.rs
+++ b/sqllogictest-engines/src/postgres.rs
@@ -47,7 +47,7 @@ impl<P> Postgres<P> {
 
     /// Returns a reference of the inner Postgres client.
     pub fn client(&self) -> &tokio_postgres::Client {
-        &self.conn.as_ref().expect("fuck").0
+        &self.conn.as_ref().expect("connection is shutdown").0
     }
 
     /// Shutdown the Postgres connection.

--- a/sqllogictest-engines/src/postgres.rs
+++ b/sqllogictest-engines/src/postgres.rs
@@ -51,10 +51,9 @@ impl<P> Postgres<P> {
     pub fn pg_client(&self) -> &tokio_postgres::Client {
         &self.client
     }
-}
 
-impl<P> Drop for Postgres<P> {
-    fn drop(&mut self) {
-        self.join_handle.abort()
+    /// Shutdown the Postgres connection.
+    async fn shutdown(&mut self) {
+        (&mut self.join_handle).await.ok();
     }
 }

--- a/sqllogictest-engines/src/postgres/extended.rs
+++ b/sqllogictest-engines/src/postgres/extended.rs
@@ -77,7 +77,7 @@ macro_rules! array_process {
                     match v {
                         Some(v) => {
                             let sql = format!("select ($1::{})::varchar", stringify!($ty_name));
-                            let tmp_rows = $self.client.query(&sql, &[&v]).await.unwrap();
+                            let tmp_rows = $self.client().query(&sql, &[&v]).await.unwrap();
                             let value: &str = tmp_rows.get(0).unwrap().get(0);
                             assert!(value.len() > 0);
                             write!(output, "{}", value).unwrap();
@@ -128,7 +128,7 @@ macro_rules! single_process {
         match value {
             Some(value) => {
                 let sql = format!("select ($1::{})::varchar", stringify!($ty_name));
-                let tmp_rows = $self.client.query(&sql, &[&value]).await.unwrap();
+                let tmp_rows = $self.client().query(&sql, &[&value]).await.unwrap();
                 let value: &str = tmp_rows.get(0).unwrap().get(0);
                 assert!(value.len() > 0);
                 $row_vec.push(value.to_string());
@@ -188,9 +188,9 @@ impl sqllogictest::AsyncDB for Postgres<Extended> {
     async fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>> {
         let mut output = vec![];
 
-        let stmt = self.client.prepare(sql).await?;
+        let stmt = self.client().prepare(sql).await?;
         let rows = self
-            .client
+            .client()
             .query_raw(&stmt, std::iter::empty::<&(dyn ToSql + Sync)>())
             .await?;
 

--- a/sqllogictest-engines/src/postgres/extended.rs
+++ b/sqllogictest-engines/src/postgres/extended.rs
@@ -311,6 +311,10 @@ impl sqllogictest::AsyncDB for Postgres<Extended> {
         }
     }
 
+    async fn shutdown(&mut self) {
+        self.shutdown().await;
+    }
+
     fn engine_name(&self) -> &str {
         "postgres-extended"
     }

--- a/sqllogictest-engines/src/postgres/simple.rs
+++ b/sqllogictest-engines/src/postgres/simple.rs
@@ -62,6 +62,10 @@ impl sqllogictest::AsyncDB for Postgres<Simple> {
         }
     }
 
+    async fn shutdown(&mut self) {
+        self.shutdown().await;
+    }
+
     fn engine_name(&self) -> &str {
         "postgres"
     }

--- a/sqllogictest-engines/src/postgres/simple.rs
+++ b/sqllogictest-engines/src/postgres/simple.rs
@@ -20,7 +20,7 @@ impl sqllogictest::AsyncDB for Postgres<Simple> {
         // and we have to follow the format given by the specific database (pg).
         // For example, postgres will output `t` as true and `f` as false,
         // thus we have to write `t`/`f` in the expected results.
-        let rows = self.client.simple_query(sql).await?;
+        let rows = self.client().simple_query(sql).await?;
         let mut cnt = 0;
         for row in rows {
             let mut row_vec = vec![];

--- a/sqllogictest/src/harness.rs
+++ b/sqllogictest/src/harness.rs
@@ -35,5 +35,6 @@ macro_rules! harness {
 pub fn test(filename: impl AsRef<Path>, make_conn: impl MakeConnection) -> Result<(), Failed> {
     let mut tester = Runner::new(make_conn);
     tester.run_file(filename)?;
+    tester.shutdown();
     Ok(())
 }

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -109,6 +109,9 @@ pub trait DB {
     /// Run a SQL query and return the output.
     fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, Self::Error>;
 
+    /// Shutdown the connection gracefully.
+    fn shutdown(&mut self) {}
+
     /// Engine name of current database.
     fn engine_name(&self) -> &str {
         ""
@@ -129,7 +132,7 @@ where
     }
 
     async fn shutdown(&mut self) {
-        // Do nothing as `DB` trait doesn't have a shutdown method.
+        D::shutdown(self);
     }
 
     fn engine_name(&self) -> &str {

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -535,13 +535,6 @@ pub struct Runner<D: AsyncDB, M: MakeConnection<Conn = D>> {
     labels: HashSet<String>,
 }
 
-impl<D: AsyncDB, M: MakeConnection<Conn = D>> Drop for Runner<D, M> {
-    fn drop(&mut self) {
-        tracing::debug!("shutting down runner...");
-        block_on(self.conn.shutdown_all());
-    }
-}
-
 impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
     /// Create a new test runner on the database, with the given connection maker.
     ///
@@ -1483,6 +1476,19 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
         override_with_outfile(filename, outfilename, outfile)?;
 
         Ok(())
+    }
+}
+
+impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
+    /// Shutdown all connections in the runner.
+    pub async fn shutdown_async(&mut self) {
+        tracing::debug!("shutting down runner...");
+        self.conn.shutdown_all().await;
+    }
+
+    /// Shutdown all connections in the runner.
+    pub fn shutdown(&mut self) {
+        block_on(self.shutdown_async());
     }
 }
 


### PR DESCRIPTION
# Changes

Add `shutdown` method to `AsyncDB`. Implement it for all engines. Adopt it in binary.

# Motivation

Previously we have a `Drop` impl for `Postgres` which directly aborts the background connection. This is not good as there's no chance for the pgwire protocol to gracefully shutdown itself. As a result, we see `failed to read message: unexpected end of file` every time a test case (file) completes in the server side.

Simply removing this `Drop` impl and letting the connection run to completion in the background resolves this issue. However, let's get one step further and propose a general design to all kinds of database engines by manually specifying and calling the `shutdown` method.

----
Signed-off-by: Bugen Zhao <i@bugenzhao.com>