### PR TITLE
feat: support getting current database name with `__DATABASE__` variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* runner(substitution): support getting the current database name in the test file by using the special variable `$__DATABASE__`. This is useful when running parallel tests in which case database names are generated.
+  ```
+  control substitution on
+
+  system ok
+  psql -d $__DATABASE__ -c "SELECT 1;"
+  ...
+  ```
+* runner: add a new `RunnerContext` parameter to `Runner::new`.
+
 ## [0.27.0] - 2025-02-11
 
 * runner: add `shutdown` method to `DB` and `AsyncDB` trait to allow for graceful shutdown of the database connection. Users are encouraged to call `Runner::shutdown` or `Runner::shutdown_async` after running tests to ensure that the database connections are properly closed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.28.0] - 2025-02-13
 
 * runner(substitution): support getting the current database name in the test file by using the special variable `$__DATABASE__`. This is useful when running parallel tests in which case database names are generated.
   ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "educe",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-bin"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-engines"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["sqllogictest", "sqllogictest-bin", "sqllogictest-engines", "tests"]
 
 [workspace.package]
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 homepage = "https://github.com/risinglightdb/sqllogictest-rs"
 keywords = ["sql", "database", "parser", "cli"]

--- a/sqllogictest-bin/Cargo.toml
+++ b/sqllogictest-bin/Cargo.toml
@@ -23,8 +23,8 @@ glob = "0.3"
 itertools = "0.13"
 quick-junit = { version = "0.5" }
 rand = "0.8"
-sqllogictest = { path = "../sqllogictest", version = "0.27" }
-sqllogictest-engines = { path = "../sqllogictest-engines", version = "0.27" }
+sqllogictest = { path = "../sqllogictest", version = "0.28" }
+sqllogictest-engines = { path = "../sqllogictest-engines", version = "0.28" }
 tokio = { version = "1", features = [
     "rt",
     "rt-multi-thread",

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -18,7 +18,7 @@ use rand::distributions::DistString;
 use rand::seq::SliceRandom;
 use sqllogictest::{
     default_column_validator, default_normalizer, default_validator, update_record_with_output,
-    AsyncDB, Injected, MakeConnection, Record, Runner,
+    AsyncDB, Injected, MakeConnection, Record, Runner, RunnerContext,
 };
 use tokio_util::task::AbortOnDropHandle;
 
@@ -462,7 +462,8 @@ async fn run_serial(
     let mut files = files.into_iter();
     let mut connection_refused = false;
     for file in &mut files {
-        let mut runner = Runner::new(|| engines::connect(engine, &config));
+        let ctx = RunnerContext::new(config.db.clone());
+        let mut runner = Runner::new(ctx, || engines::connect(engine, &config));
         for label in labels {
             runner.add_label(label);
         }
@@ -538,7 +539,8 @@ async fn update_test_files(
     format: bool,
 ) -> Result<()> {
     for file in files {
-        let mut runner = Runner::new(|| engines::connect(engine, &config));
+        let ctx = RunnerContext::new(config.db.clone());
+        let mut runner = Runner::new(ctx, || engines::connect(engine, &config));
 
         if let Err(e) = update_test_file(&mut std::io::stdout(), &mut runner, &file, format).await {
             {
@@ -564,7 +566,8 @@ async fn connect_and_run_test_file(
     config: DBConfig,
     labels: &[String],
 ) -> Result<Duration> {
-    let mut runner = Runner::new(|| engines::connect(engine, &config));
+    let ctx = RunnerContext::new(config.db.clone());
+    let mut runner = Runner::new(ctx, || engines::connect(engine, &config));
     for label in labels {
         runner.add_label(label);
     }

--- a/sqllogictest-engines/Cargo.toml
+++ b/sqllogictest-engines/Cargo.toml
@@ -14,13 +14,15 @@ bytes = "1"
 chrono = { version = "0.4" }
 futures = { version = "0.3", default-features = false }
 log = "0.4"
-mysql_async = { version = "0.34.2", default-features = false, features = ["minimal"] }
+mysql_async = { version = "0.34.2", default-features = false, features = [
+    "minimal",
+] }
 pg_interval = "0.4"
 postgres-types = { version = "0.2.8", features = ["derive", "with-chrono-0_4"] }
 rust_decimal = { version = "1.36.0", features = ["tokio-pg"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqllogictest = { path = "../sqllogictest", version = "0.27" }
+sqllogictest = { path = "../sqllogictest", version = "0.28" }
 thiserror = "2"
 tokio = { version = "1", features = [
     "rt",

--- a/sqllogictest/src/harness.rs
+++ b/sqllogictest/src/harness.rs
@@ -3,14 +3,15 @@ use std::path::Path;
 pub use glob::glob;
 pub use libtest_mimic::{run, Arguments, Failed, Trial};
 
-use crate::{MakeConnection, Runner};
+use crate::{MakeConnection, Runner, RunnerContext};
 
+/// * `db_name`: The name of the database.
 /// * `db_fn`: `fn() -> sqllogictest::AsyncDB`
 /// * `pattern`: The glob used to match against and select each file to be tested. It is relative to
 ///   the root of the crate.
 #[macro_export]
 macro_rules! harness {
-    ($db_fn:path, $pattern:expr) => {
+    ($db_name:literal, $db_fn:path, $pattern:expr) => {
         fn main() {
             let paths = $crate::harness::glob($pattern).expect("failed to find test files");
             let mut tests = vec![];
@@ -19,7 +20,7 @@ macro_rules! harness {
                 let path = entry.expect("failed to read glob entry");
                 tests.push($crate::harness::Trial::test(
                     path.to_str().unwrap().to_string(),
-                    move || $crate::harness::test(&path, || async { Ok($db_fn()) }),
+                    move || $crate::harness::test(db_name, &path, || async { Ok($db_fn()) }),
                 ));
             }
 
@@ -32,8 +33,13 @@ macro_rules! harness {
     };
 }
 
-pub fn test(filename: impl AsRef<Path>, make_conn: impl MakeConnection) -> Result<(), Failed> {
-    let mut tester = Runner::new(make_conn);
+pub fn test(
+    filename: impl AsRef<Path>,
+    db_name: impl ToOwned<Owned = String>,
+    make_conn: impl MakeConnection,
+) -> Result<(), Failed> {
+    let ctx = RunnerContext::new(db_name.to_owned());
+    let mut tester = Runner::new(ctx, make_conn);
     tester.run_file(filename)?;
     tester.shutdown();
     Ok(())

--- a/sqllogictest/src/harness.rs
+++ b/sqllogictest/src/harness.rs
@@ -20,7 +20,9 @@ macro_rules! harness {
                 let path = entry.expect("failed to read glob entry");
                 tests.push($crate::harness::Trial::test(
                     path.to_str().unwrap().to_string(),
-                    move || $crate::harness::test(db_name, &path, || async { Ok($db_fn()) }),
+                    move || {
+                        $crate::harness::test(&path, $db_name.to_owned(), || async { Ok($db_fn()) })
+                    },
                 ));
             }
 
@@ -35,7 +37,7 @@ macro_rules! harness {
 
 pub fn test(
     filename: impl AsRef<Path>,
-    db_name: impl ToOwned<Owned = String>,
+    db_name: String,
     make_conn: impl MakeConnection,
 ) -> Result<(), Failed> {
     let ctx = RunnerContext::new(db_name.to_owned());

--- a/sqllogictest/src/lib.rs
+++ b/sqllogictest/src/lib.rs
@@ -37,7 +37,8 @@
 //! }
 //!
 //! // Then create a `Runner` on your database instance, and run the tests:
-//! let mut tester = sqllogictest::Runner::new(|| async {
+//! let ctx = sqllogictest::RunnerContext::new("the_db_name".to_owned());
+//! let mut tester = sqllogictest::Runner::new(ctx, || async {
 //!     let db = MyDatabase {
 //!         // fields
 //!     };

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -1294,7 +1294,7 @@ impl<D: AsyncDB, M: MakeConnection<Conn = D>> Runner<D, M> {
                 validator: self.validator,
                 normalizer: self.normalizer,
                 column_type_validator: self.column_type_validator,
-                substitution: self.substitution.clone(),
+                substitution: self.substitution,
                 sort_mode: self.sort_mode,
                 result_mode: self.result_mode,
                 hash_threshold: self.hash_threshold,

--- a/sqllogictest/src/substitution.rs
+++ b/sqllogictest/src/substitution.rs
@@ -3,8 +3,8 @@ use subst::Env;
 use crate::RunnerContext;
 
 /// Substitute environment variables and special variables like `__TEST_DIR__` in SQL.
-#[derive(Default, Clone)]
-pub(crate) struct Substitution {
+#[derive(Clone)]
+pub(crate) struct Substitution<'a> {
     pub(crate) runner_ctx: &'a RunnerContext,
 }
 
@@ -12,7 +12,7 @@ pub(crate) struct Substitution {
 #[error("substitution failed: {0}")]
 pub(crate) struct SubstError(subst::Error);
 
-impl Substitution {
+impl Substitution<'_> {
     pub fn substitute(&self, input: &str, subst_env_vars: bool) -> Result<String, SubstError> {
         if !subst_env_vars {
             Ok(input

--- a/tests/custom_type/custom_type.rs
+++ b/tests/custom_type/custom_type.rs
@@ -66,7 +66,8 @@ impl sqllogictest::DB for FakeDB {
 
 #[test]
 fn test() {
-    let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB) });
+    let ctx = sqllogictest::RunnerContext::new("fake_db".to_owned());
+    let mut tester = sqllogictest::Runner::new(ctx, || async { Ok(FakeDB) });
     tester.with_column_validator(strict_column_validator);
 
     let r = tester.run_file("./custom_type/custom_type.slt");

--- a/tests/harness.rs
+++ b/tests/harness.rs
@@ -1,6 +1,6 @@
 use sqllogictest::{DBOutput, DefaultColumnType};
 
-sqllogictest::harness!(FakeDB::new, "slt/**/*.slt");
+sqllogictest::harness!("fake_db", FakeDB::new, "slt/**/*.slt");
 
 pub struct FakeDB {
     counter: u64,

--- a/tests/substitution/basic.slt
+++ b/tests/substitution/basic.slt
@@ -29,6 +29,10 @@ path $__TEST_DIR__
 statement ok
 time $__NOW__
 
+# a special variable `__DATABASE__` to get the current database name
+statement ok
+check $__DATABASE__
+
 # non existent variables without default values are errors
 statement error No such variable
 check $NONEXISTENT_VARIABLE

--- a/tests/substitution/substitution.rs
+++ b/tests/substitution/substitution.rs
@@ -58,7 +58,8 @@ rusty_fork_test! {
         std::env::set_var("MY_USERNAME", "sqllogictest");
         std::env::set_var("MY_PASSWORD", "rust");
 
-        let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB) });
+        let ctx = sqllogictest::RunnerContext::new("fake_db".to_owned());
+        let mut tester = sqllogictest::Runner::new(ctx, || async { Ok(FakeDB) });
 
         tester.run_file("./substitution/basic.slt").unwrap();
     }

--- a/tests/system_command/system_command.rs
+++ b/tests/system_command/system_command.rs
@@ -41,7 +41,8 @@ impl sqllogictest::DB for FakeDB {
 
 #[test]
 fn test() {
-    let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB) });
+    let ctx = sqllogictest::RunnerContext::new("fake_db".to_owned());
+    let mut tester = sqllogictest::Runner::new(ctx, || async { Ok(FakeDB) });
 
     if let Err(e) = tester.run_file("./system_command/system_command.slt") {
         println!("{}", e.display(true));
@@ -51,7 +52,8 @@ fn test() {
 
 #[test]
 fn test_fail() {
-    let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB) });
+    let ctx = sqllogictest::RunnerContext::new("fake_db".to_owned());
+    let mut tester = sqllogictest::Runner::new(ctx, || async { Ok(FakeDB) });
 
     let err = tester
         .run_file("./system_command/system_command_fail.slt")

--- a/tests/test_dir_escape/test_dir_escape.rs
+++ b/tests/test_dir_escape/test_dir_escape.rs
@@ -27,7 +27,8 @@ impl sqllogictest::DB for FakeDB {
 
 #[test]
 fn test() {
-    let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB) });
+    let ctx = sqllogictest::RunnerContext::new("fake_db".to_owned());
+    let mut tester = sqllogictest::Runner::new(ctx, || async { Ok(FakeDB) });
 
     tester
         .run_file("./test_dir_escape/test_dir_escape.slt")

--- a/tests/validator/validator.rs
+++ b/tests/validator/validator.rs
@@ -27,7 +27,8 @@ impl sqllogictest::DB for FakeDB {
 
 #[test]
 fn test() {
-    let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB) });
+    let ctx = sqllogictest::RunnerContext::new("fake_db".to_owned());
+    let mut tester = sqllogictest::Runner::new(ctx, || async { Ok(FakeDB) });
     // Validator will always return true.
     tester.with_validator(|_, _, _| true);
 


### PR DESCRIPTION
So that we can get the auto-generated database name when running parallel tests:

```
control substitution on

system ok
psql -d $__DATABASE__ -c "SELECT 1;"
...
```