### PR TITLE
feat: support local variable substitution, add `__DATABASE__` variable for bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* runner: Add `Runner::set_var` method to allow adding runner-local variables for substitution.
+* bin: Add `__DATABASE__` variable for accessing current database name from SLT files.
+
 ## [0.27.0] - 2025-02-11
 
 * runner: add `shutdown` method to `DB` and `AsyncDB` trait to allow for graceful shutdown of the database connection. Users are encouraged to call `Runner::shutdown` or `Runner::shutdown_async` after running tests to ensure that the database connections are properly closed.

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -16,6 +16,7 @@ use itertools::Itertools;
 use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite};
 use rand::distributions::DistString;
 use rand::seq::SliceRandom;
+use sqllogictest::substitution::well_known;
 use sqllogictest::{
     default_column_validator, default_normalizer, default_validator, update_record_with_output,
     AsyncDB, Injected, MakeConnection, Record, Runner,
@@ -466,6 +467,7 @@ async fn run_serial(
         for label in labels {
             runner.add_label(label);
         }
+        runner.set_var(well_known::DATABASE.to_owned(), config.db.clone());
 
         let filename = file.to_string_lossy().to_string();
         let test_case_name = filename.replace(['/', ' ', '.', '-'], "_");
@@ -539,6 +541,7 @@ async fn update_test_files(
 ) -> Result<()> {
     for file in files {
         let mut runner = Runner::new(|| engines::connect(engine, &config));
+        runner.set_var(well_known::DATABASE.to_owned(), config.db.clone());
 
         if let Err(e) = update_test_file(&mut std::io::stdout(), &mut runner, &file, format).await {
             {
@@ -568,6 +571,7 @@ async fn connect_and_run_test_file(
     for label in labels {
         runner.add_label(label);
     }
+    runner.set_var(well_known::DATABASE.to_owned(), config.db.clone());
     let result = run_test_file(out, &mut runner, filename).await;
     runner.shutdown_async().await;
 

--- a/sqllogictest/src/lib.rs
+++ b/sqllogictest/src/lib.rs
@@ -57,10 +57,9 @@ pub mod connection;
 pub mod harness;
 pub mod parser;
 pub mod runner;
+pub mod substitution;
 
 pub use self::column_type::*;
 pub use self::connection::*;
 pub use self::parser::*;
 pub use self::runner::*;
-
-mod substitution;

--- a/sqllogictest/src/substitution.rs
+++ b/sqllogictest/src/substitution.rs
@@ -1,55 +1,75 @@
-use std::sync::{Arc, OnceLock};
-
 use subst::Env;
-use tempfile::{tempdir, TempDir};
+
+use crate::RunnerLocals;
+
+pub mod well_known {
+    pub const TEST_DIR: &str = "__TEST_DIR__";
+    pub const NOW: &str = "__NOW__";
+    pub const DATABASE: &str = "__DATABASE__";
+}
 
 /// Substitute environment variables and special variables like `__TEST_DIR__` in SQL.
-#[derive(Default, Clone)]
-pub(crate) struct Substitution {
-    /// The temporary directory for `__TEST_DIR__`.
-    /// Lazily initialized and cleaned up when dropped.
-    test_dir: Arc<OnceLock<TempDir>>,
+pub(crate) struct Substitution<'a> {
+    runner_locals: &'a RunnerLocals,
+    subst_env_vars: bool,
+}
+
+impl Substitution<'_> {
+    pub fn new(runner_locals: &RunnerLocals, subst_env_vars: bool) -> Substitution {
+        Substitution {
+            runner_locals,
+            subst_env_vars,
+        }
+    }
 }
 
 #[derive(thiserror::Error, Debug)]
 #[error("substitution failed: {0}")]
 pub(crate) struct SubstError(subst::Error);
 
-impl Substitution {
-    pub fn substitute(&self, input: &str, subst_env_vars: bool) -> Result<String, SubstError> {
-        if !subst_env_vars {
-            Ok(input
-                .replace("$__TEST_DIR__", &self.test_dir())
-                .replace("$__NOW__", &self.now()))
-        } else {
+fn now_string() -> String {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("failed to get current time")
+        .as_nanos()
+        .to_string()
+}
+
+impl Substitution<'_> {
+    pub fn substitute(&self, input: &str) -> Result<String, SubstError> {
+        if self.subst_env_vars {
             subst::substitute(input, self).map_err(SubstError)
+        } else {
+            Ok(self.simple_replace(input))
         }
     }
 
-    fn test_dir(&self) -> String {
-        let test_dir = self
-            .test_dir
-            .get_or_init(|| tempdir().expect("failed to create testdir"));
-        test_dir.path().to_string_lossy().into_owned()
-    }
-
-    fn now(&self) -> String {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("failed to get current time")
-            .as_nanos()
-            .to_string()
+    fn simple_replace(&self, input: &str) -> String {
+        let mut res = input
+            .replace(
+                &format!("${}", well_known::TEST_DIR),
+                &self.runner_locals.test_dir(),
+            )
+            .replace(&format!("${}", well_known::NOW), &now_string());
+        for (key, value) in self.runner_locals.vars() {
+            res = res.replace(&format!("${}", key), value);
+        }
+        res
     }
 }
 
-impl<'a> subst::VariableMap<'a> for Substitution {
+impl<'a> subst::VariableMap<'a> for Substitution<'a> {
     type Value = String;
 
     fn get(&'a self, key: &str) -> Option<Self::Value> {
         match key {
-            "__TEST_DIR__" => self.test_dir().into(),
-            "__NOW__" => self.now().into(),
-            key => Env.get(key),
+            well_known::TEST_DIR => self.runner_locals.test_dir().into(),
+            well_known::NOW => now_string().into(),
+            key => self
+                .runner_locals
+                .get_var(key)
+                .cloned()
+                .or_else(|| Env.get(key)),
         }
     }
 }

--- a/tests/substitution/basic.slt
+++ b/tests/substitution/basic.slt
@@ -29,6 +29,10 @@ path $__TEST_DIR__
 statement ok
 time $__NOW__
 
+# a local variable set before running tester
+statement ok
+check $__DATABASE__
+
 # non existent variables without default values are errors
 statement error No such variable
 check $NONEXISTENT_VARIABLE

--- a/tests/substitution/substitution.rs
+++ b/tests/substitution/substitution.rs
@@ -1,5 +1,5 @@
 use rusty_fork::rusty_fork_test;
-use sqllogictest::{DBOutput, DefaultColumnType};
+use sqllogictest::{substitution::well_known, DBOutput, DefaultColumnType};
 
 pub struct FakeDB;
 
@@ -59,6 +59,7 @@ rusty_fork_test! {
         std::env::set_var("MY_PASSWORD", "rust");
 
         let mut tester = sqllogictest::Runner::new(|| async { Ok(FakeDB) });
+        tester.set_var(well_known::DATABASE.to_owned(), "fake_db".to_owned());
 
         tester.run_file("./substitution/basic.slt").unwrap();
     }


### PR DESCRIPTION
- runner: Add `Runner::set_var` method to add runner-local variables for substitution.
- bin: Add `__DATABASE__` variable for accessing database name from SLT files.