### PR TITLE
ci: cargo publish on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,3 +120,19 @@ jobs:
         asset_path: ${{ env.ASSET }}
         asset_name: ${{ env.ASSET }}
         asset_content_type: application/octet-stream
+
+  cargo-publish:
+    name: cargo-publish
+    needs: build-release
+    runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup show
+      - name: Cargo publish
+        run: |
+          cargo publish -p sqllogictest
+          cargo publish -p sqllogictest-engines
+          cargo publish -p sqllogictest-bin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.27.1] - 2025-02-17
+
 * runner: Add `Runner::set_var` method to allow adding runner-local variables for substitution.
 * bin: Add `__DATABASE__` variable for accessing current database name from SLT files.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "async-trait",
  "educe",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-bin"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-engines"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["sqllogictest", "sqllogictest-bin", "sqllogictest-engines", "tests"]
 
 [workspace.package]
-version = "0.27.0"
+version = "0.27.1"
 edition = "2021"
 homepage = "https://github.com/risinglightdb/sqllogictest-rs"
 keywords = ["sql", "database", "parser", "cli"]


### PR DESCRIPTION
So that we don't need to both push tags and manually run `cargo publish`. And anyone with push tag permission can publish now. 

cc @risinglightdb/crates-io 