### PR TITLE
fix(external): close stdin properly in shutdown()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.27.2] - 2025-02-18
+
 * engines/bin: fix stdin to be closed properly to avoid hangs in the `external` engine.
 
 ## [0.27.1] - 2025-02-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* engines/bin: fix stdin to be closed properly to avoid hangs in the `external` engine.
+
 ## [0.27.1] - 2025-02-17
 
 * runner: Add `Runner::set_var` method to allow adding runner-local variables for substitution.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "async-trait",
  "educe",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-bin"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest-engines"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["sqllogictest", "sqllogictest-bin", "sqllogictest-engines", "tests"]
 
 [workspace.package]
-version = "0.27.1"
+version = "0.27.2"
 edition = "2021"
 homepage = "https://github.com/risinglightdb/sqllogictest-rs"
 keywords = ["sql", "database", "parser", "cli"]

--- a/sqllogictest-engines/src/external.rs
+++ b/sqllogictest-engines/src/external.rs
@@ -98,10 +98,11 @@ impl AsyncDB for ExternalDriver {
             sql: sql.to_string(),
         };
         let input = serde_json::to_string(&input)?;
-        match &mut self.stdin {
-            Some(stdin) => stdin.write_all(input.as_bytes()).await?,
-            None => return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into()),
-        };
+        self.stdin
+            .as_mut()
+            .expect("external driver is shutdown")
+            .write_all(input.as_bytes())
+            .await?;
 
         let output = match self.stdout.next().await {
             Some(Ok(output)) => output,


### PR DESCRIPTION
it seems that we can not pass EOF to child process's stdin by `shutdown()`.

as the doc from tokio described, `shutdown()` will fire a `shutdown(Write)` syscall to the socket. but this syscall does not works for file descriptors other than socket.

```
        /// Shuts down the output stream, ensuring that the value can be dropped
        /// cleanly.
        ///
        /// Equivalent to:
        ///
        /// ```ignore
        /// async fn shutdown(&mut self) -> io::Result<()>;
        /// ```
        ///
        /// Similar to [`flush`], all intermediately buffered is written to the
        /// underlying stream. Once the operation completes, the caller should
        /// no longer attempt to write to the stream. For example, the
        /// `TcpStream` implementation will issue a `shutdown(Write)` sys call.
        ///
        /// [`flush`]: fn@crate::io::AsyncWriteExt::flush
```


to real `close()` the fd to pass the eof properly to the child process, we have to `drop()` this stdin to close it.

i made an experiment in: https://gist.github.com/flaneur2020/4e74d7c8acc6b8dbe41cacb28c131dba . this program will keep hangs with `shutdown()`, and will runs as expected with `drop()`.

this pr fixed the `shutdown()` to `drop()` to close the file descriptor properly.