### PR TITLE
feat(bin): handle cancellation & early-exit & ctrl-c gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* bin: Support graceful shutdown. When receiving a `Ctrl-C`, the program will cancel all running test cases, log cancelled and skipped test cases, drop temporary databases (if in parallel mode), close database connections, and finally exit with a non-zero code.
+
 ## [0.28.0] - 2025-03-06
 
 * runner: Add `Partitioner` and `Runner::with_partitioner` to enable partitioning of test cases, allowing only a subset of the glob result to be executed. This can be helpful for running tests in parallel in CI.

--- a/sqllogictest-bin/Cargo.toml
+++ b/sqllogictest-bin/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { version = "1", features = [
     "macros",
     "fs",
     "process",
+    "signal",
 ] }
 tokio-util = { version = "0.7.12", features = ["rt"] }
 fs-err = "3.0.0"

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -331,9 +331,13 @@ pub async fn main() -> Result<()> {
     tokio::spawn({
         let cancel = cancel.clone();
         async move {
-            tokio::signal::ctrl_c().await.unwrap();
-            eprintln!("Ctrl-C received, cancelling...");
-            cancel.cancel();
+            match tokio::signal::ctrl_c().await {
+                Ok(_) => {
+                    eprintln!("Ctrl-C received, cancelling...");
+                    cancel.cancel();
+                }
+                Err(err) => eprintln!("Failed to listen for Ctrl-C signal: {}", err),
+            }
         }
     });
 


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

Significantly refactor the `bin` impl and enhance the cancellation handling:

- Extract `connect_and_run_test_file` to be shared by both `run_parallel` and `run_serial`.
- Extract the common logic for converting a test result into a JUnit test case in `run_parallel` and `run_serial`.
- Introduce `CancellationToken` to unify all kinds of cancellation, including `--fail-fast` (#246) and early-exit on "connection refused" (#248).
- Support `Ctrl-C` as an origin of cancellation.
- In parallel mode: when cancellation is triggered, we will first await all running cases to be cancelled (disconnecting their sessions), then skip the ones that haven't started.
- Also output lines for `[CANCELLED]` or `[SKIPPED]` test cases. This can be very useful to locate which test case runs slow or even gets stuck.

Example for `--fail-fast`:
<img width="766" alt="image" src="https://github.com/user-attachments/assets/7be15127-4d6d-48c6-a6dc-3805700d169f" />

Example for ctrl-c:
<img width="757" alt="image" src="https://github.com/user-attachments/assets/31d66b75-c5f2-490a-ab1f-eb91017d3a14" />
