### PR TITLE
feat(engines): cancel ongoing query when shutting down postgres connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* engines: Enhance graceful shutdown by canceling ongoing queries when shutting down postgres connections. This improves the behavior when receiving a `Ctrl-C` signal by ensuring that any long-running queries are properly canceled before the connection is closed.
+
 ## [0.28.1] - 2025-04-18
 
 * bin: Support graceful shutdown. When receiving a `Ctrl-C`, the program will cancel all running test cases, log cancelled and skipped test cases, drop temporary databases (if in parallel mode), close database connections, and finally exit with a non-zero code.

--- a/sqllogictest-engines/src/postgres.rs
+++ b/sqllogictest-engines/src/postgres.rs
@@ -53,6 +53,14 @@ impl<P> Postgres<P> {
     /// Shutdown the Postgres connection.
     async fn shutdown(&mut self) {
         if let Some((client, connection)) = self.conn.take() {
+            if let Err(e) = client
+                .cancel_token()
+                .cancel_query(tokio_postgres::NoTls)
+                .await
+            {
+                log::warn!("Failed to cancel query during shutdown: {:?}", e);
+            }
+
             drop(client);
             connection.await.ok();
         }


### PR DESCRIPTION
Otherwise we have to wait for the ongoing query to be finished before `shutdown` can return, which doesn't seem friendly when handling cancellation from the user.