### PR TITLE
fix(bin): add missing newline in override mode

### DIFF
--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -986,6 +986,8 @@ async fn update_test_file<T: std::io::Write, M: MakeConnection>(
         &filename.to_string_lossy(),
     )?;
 
+    writeln!(out)?;
+
     let Item {
         filename,
         outfilename,


### PR DESCRIPTION
Signed-off-by: Cheng Chen <ccqmpux@gmail.com>

Without the fix, override mode omits the final newline, resulting in output like:
```
vscode ➜ /workspaces/pg_mooncake (rust) $ sqllogictest tests/sanity.slt --override
tests/sanity.slt                                             .. [OK] in 11 msvscode ➜ /workspaces/pg_mooncake (rust ✗) $ 
```
In contrast, non-override mode prints the newline correctly:
```
vscode ➜ /workspaces/pg_mooncake (rust ✗) $ sqllogictest tests/sanity.slt
tests/sanity.slt                                             .. [OK] in 5 ms
vscode ➜ /workspaces/pg_mooncake (rust ✗) $ 
```