### PR TITLE
feat: support matching sqlstate with `[statement|query] error (XX000)`

### DIFF
--- a/sqllogictest-engines/src/mysql.rs
+++ b/sqllogictest-engines/src/mysql.rs
@@ -81,4 +81,12 @@ impl sqllogictest::AsyncDB for MySql {
     async fn run_command(command: Command) -> std::io::Result<std::process::Output> {
         tokio::process::Command::from(command).output().await
     }
+
+    fn error_sql_state(err: &Self::Error) -> Option<String> {
+        if let mysql_async::Error::Server(err) = err {
+            Some(err.state.clone())
+        } else {
+            None
+        }
+    }
 }

--- a/sqllogictest-engines/src/postgres/extended.rs
+++ b/sqllogictest-engines/src/postgres/extended.rs
@@ -326,4 +326,8 @@ impl sqllogictest::AsyncDB for Postgres<Extended> {
     async fn run_command(command: Command) -> std::io::Result<std::process::Output> {
         tokio::process::Command::from(command).output().await
     }
+
+    fn error_sql_state(err: &Self::Error) -> Option<String> {
+        err.code().map(|s| s.code().to_owned())
+    }
 }

--- a/sqllogictest-engines/src/postgres/simple.rs
+++ b/sqllogictest-engines/src/postgres/simple.rs
@@ -77,4 +77,8 @@ impl sqllogictest::AsyncDB for Postgres<Simple> {
     async fn run_command(command: Command) -> std::io::Result<std::process::Output> {
         tokio::process::Command::from(command).output().await
     }
+
+    fn error_sql_state(err: &Self::Error) -> Option<String> {
+        err.code().map(|s| s.code().to_owned())
+    }
 }

--- a/sqllogictest/src/runner.rs
+++ b/sqllogictest/src/runner.rs
@@ -98,6 +98,11 @@ pub trait AsyncDB {
     async fn run_command(mut command: Command) -> std::io::Result<std::process::Output> {
         command.output()
     }
+
+    /// Extract the SQL state from the error.
+    fn error_sql_state(_err: &Self::Error) -> Option<String> {
+        None
+    }
 }
 
 /// The database to be tested.
@@ -116,6 +121,11 @@ pub trait DB {
     /// Engine name of current database.
     fn engine_name(&self) -> &str {
         ""
+    }
+
+    /// Extract the SQL state from the error.
+    fn error_sql_state(_err: &Self::Error) -> Option<String> {
+        None
     }
 }
 
@@ -138,6 +148,10 @@ where
 
     fn engine_name(&self) -> &str {
         D::engine_name(self)
+    }
+
+    fn error_sql_state(err: &Self::Error) -> Option<String> {
+        D::error_sql_state(err)
     }
 }
 

--- a/tests/harness.rs
+++ b/tests/harness.rs
@@ -13,11 +13,30 @@ impl FakeDB {
 }
 
 #[derive(Debug)]
-pub struct FakeDBError(String);
+pub struct FakeDBError {
+    message: String,
+    sql_state: Option<String>,
+}
+
+impl FakeDBError {
+    fn new(message: String) -> Self {
+        Self {
+            message,
+            sql_state: None,
+        }
+    }
+
+    fn with_sql_state(message: String, sql_state: String) -> Self {
+        Self {
+            message,
+            sql_state: Some(sql_state),
+        }
+    }
+}
 
 impl std::fmt::Display for FakeDBError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.message)
     }
 }
 
@@ -71,15 +90,63 @@ impl sqllogictest::DB for FakeDB {
             return Ok(DBOutput::StatementComplete(0));
         }
         if sql.starts_with("desc") {
-            return Err(FakeDBError(
+            return Err(FakeDBError::new(
                 "The operation (describe) is not supported. Did you mean [describe]?".to_string(),
             ));
         }
         if sql.contains("multiline error") {
-            return Err(FakeDBError(
+            return Err(FakeDBError::new(
                 "Hey!\n\nYou got:\n  Multiline FakeDBError!".to_string(),
             ));
         }
-        Err(FakeDBError("Hey you got FakeDBError!".to_string()))
+
+        // Handle SQL state error testing
+        // Order matters: more specific patterns should come first
+        if sql.contains("non_existent_column") || sql.contains("missing_column") {
+            return Err(FakeDBError::with_sql_state(
+                "column \"missing_column\" does not exist".to_string(),
+                "42703".to_string(),
+            ));
+        }
+        if sql.contains("FORM") || sql.contains("SELEKT") || sql.contains("INVALID SYNTAX") {
+            return Err(FakeDBError::with_sql_state(
+                "syntax error at or near \"FORM\"".to_string(),
+                "42601".to_string(),
+            ));
+        }
+        if sql.contains("1/0") || sql.contains("/0") {
+            return Err(FakeDBError::with_sql_state(
+                "division by zero".to_string(),
+                "22012".to_string(),
+            ));
+        }
+        if sql.contains("duplicate") || sql.contains("UNIQUE") || sql.contains("violation") {
+            return Err(FakeDBError::with_sql_state(
+                "duplicate key value violates unique constraint".to_string(),
+                "23505".to_string(),
+            ));
+        }
+        if sql.contains("non_existent_table")
+            || sql.contains("missing_table")
+            || sql.contains("table_that_does_not_exist")
+            || sql.contains("final_missing_table")
+            || sql.contains("query_missing_table")
+            || sql.contains("another_missing_table")
+            || sql.contains("yet_another_missing_table")
+            || sql.contains("definitely_missing_table")
+            || sql.contains("postgres_missing_table")
+            || sql.contains("some_missing_table")
+        {
+            return Err(FakeDBError::with_sql_state(
+                "relation \"missing_table\" does not exist".to_string(),
+                "42P01".to_string(),
+            ));
+        }
+
+        Err(FakeDBError::new("Hey you got FakeDBError!".to_string()))
+    }
+
+    fn error_sql_state(err: &Self::Error) -> Option<String> {
+        err.sql_state.clone()
     }
 }

--- a/tests/slt/error_sqlstate.slt
+++ b/tests/slt/error_sqlstate.slt
@@ -1,0 +1,160 @@
+# Test file for error(sqlstate) syntax support
+# This file tests the parsing and matching of SQL state error codes
+# in both statement and query contexts using the enhanced FakeDB
+
+# Test 1: Table not found error (SQL state 42P01)
+# This tests the most common error case
+statement error (42P01)
+SELECT * FROM non_existent_table
+
+query error (42P01)
+SELECT * FROM missing_table
+
+# Test 2: Column not found error (SQL state 42703)
+statement error (42703)
+SELECT non_existent_column FROM some_table
+
+query error (42703)
+SELECT missing_column FROM another_table
+
+# Test 3: Syntax error (SQL state 42601)
+statement error (42601)
+SELECT * FORM some_table
+
+query error (42601)
+SELEKT * FROM some_table
+
+# Test 4: Division by zero error (SQL state 22012)
+statement error (22012)
+SELECT 1/0
+
+query error (22012)
+SELECT id/0 FROM some_table
+
+# Test 5: Duplicate key error (SQL state 23505)
+# Simulate duplicate key constraint violations
+statement error (23505)
+INSERT INTO table_with_duplicate VALUES (1)
+
+query error (23505)
+INSERT INTO table_with_UNIQUE_constraint VALUES (1)
+
+# Test 6: Test backward compatibility - ensure regular error matching still works
+statement error Hey you got FakeDBError
+SELECT * FROM any_table
+
+statement error relation.*does not exist
+SELECT * FROM missing_table
+
+# Test 7: Test both inline and multiline error formats work alongside sqlstate
+statement error (42P01)
+SELECT * FROM another_missing_table
+
+statement error
+give me a multiline error
+----
+Hey!
+
+You got:
+  Multiline FakeDBError!
+
+
+# Test 8: Test empty error (any error should match)
+statement error
+SELECT * FROM some_table
+
+query error
+SELECT anything FROM anywhere
+
+# Test 9: Verify parsing of different SQL state formats
+# Test case preservation
+statement error (42P01)
+SELECT * FROM missing_table
+
+statement error (42P01)
+SELECT * FROM missing_table
+
+statement error (42703)
+SELECT missing_column FROM table
+
+# Test 10: Test complex SQL with SQL state matching
+statement error (42601)
+SELECT col1, col2 FORM table WHERE id = 1
+
+query error (42601)
+SELEKT COUNT(*) FROM table GROUP BY col1
+
+# Test 11: Test division by zero in different contexts
+statement error (22012)
+SELECT price/0 FROM products
+
+query error (22012)
+SELECT quantity/0 AS invalid FROM inventory
+
+# Test 12: Multiple table references with missing table error
+statement error (42P01)
+SELECT t1.id, t2.name FROM missing_table t1 JOIN other_table t2 ON t1.id = t2.id
+
+query error (42P01)
+SELECT * FROM (SELECT * FROM non_existent_table) AS subquery
+
+# Test 13: Test that SQL state matching is exact
+# This should match the SQL state exactly, not partially
+statement error (42P01)
+SELECT * FROM missing_table WHERE id = 1
+
+# These should NOT match because they don't contain the right patterns
+statement error Hey you got FakeDBError
+SELECT * FROM some_existing_table
+
+statement error Hey you got FakeDBError
+INSERT INTO real_table VALUES (1)
+
+# Test 14: Verify normal operations still work
+statement ok
+create table test_table (id int)
+
+statement ok
+insert into test_table values (1)
+
+statement ok
+drop table test_table
+
+# Test 15: Test description operation error (from original harness)
+statement error The operation \(describe\) is not supported
+desc table some_table
+
+query error The operation \(describe\) is not supported
+desc table another_table
+
+# Test 16: Test that multiple SQL patterns work correctly
+statement error (42703)
+SELECT missing_column, another_missing_column FROM table
+
+statement error (42601)
+SELEKT * FORM table WHERE col = 'value'
+
+# Test 17: Ensure the SQL state pattern parsing is robust
+# Test with extra whitespace and different formats
+statement error (42P01)
+SELECT * FROM missing_table
+
+# This should be treated as regex, not SQL state (invalid format)
+statement error missing.*table
+SELECT * FROM missing_table
+
+# Test 18: Final verification that all error types work
+statement error (42P01)
+SELECT * FROM final_missing_table
+
+query error (42703)
+SELECT final_missing_column FROM table
+
+statement error (42601)
+FINAL INVALID SYNTAX FORM
+
+query error (22012)
+SELECT final/0 FROM table
+
+statement error (23505)
+INSERT final duplicate key violation

--- a/tests/slt/error_sqlstate_parsing.slt
+++ b/tests/slt/error_sqlstate_parsing.slt
@@ -1,0 +1,72 @@
+# Unit tests for error(sqlstate) parsing functionality
+# This file focuses on testing the parser's ability to correctly parse 
+# different SQL state error patterns
+
+# Test 1: Basic SQL state pattern parsing
+# Verify that the parser correctly identifies sqlstate patterns
+statement error (42P01)
+SELECT invalid_syntax FROM non_existent_table
+
+# Test 2: Alphanumeric SQL state codes
+# Some SQL states contain letters (like PostgreSQL codes)
+statement error (42P01)
+SELECT * FROM missing_table
+
+# Test 3: Different SQL state lengths
+# Test both 5-character standard SQL states and variations
+statement error (42P01)
+INSERT INTO non_existent_table VALUES (1)
+
+statement error (42703)
+SELECT non_existent_column FROM missing_table
+
+# Test 4: Mixed case SQL state codes (should be preserved as-is)
+statement error (42P01)
+SELECT * FROM another_missing_table
+
+statement error (42P01)
+SELECT * FROM yet_another_missing_table
+
+# Test 5: Ensure regular error patterns still work
+# This verifies backward compatibility
+statement error relation.*does not exist
+SELECT * FROM definitely_missing_table
+
+statement error relation.*does not exist
+SELECT * FROM postgres_missing_table
+
+# Test 6: Test both statement and query error contexts
+query error (42P01)
+SELECT * FROM query_missing_table
+
+query error (42P01)
+SELECT * FROM query_missing_table2
+
+# Test 7: Ensure multiline errors still work with regular expressions
+statement error
+give me a multiline error
+----
+Hey!
+
+You got:
+  Multiline FakeDBError!
+
+
+# Test 8: Test empty error (any error should match)
+statement error
+SELECT * FROM some_missing_table
+
+# Test 9: Test syntax error SQL state codes
+statement error (42601)
+SELECT * FORM missing_table
+
+statement error (42601)
+SELEKT * FROM missing_table
+
+# Test 10: Edge cases - what happens with different parentheses patterns
+# Note: These should be treated as regular regex patterns, not SQL states
+statement error Hey you got FakeDBError
+SELECT * FROM some_other_table
+
+statement error missing.*table
+SELECT * FROM final_missing_table


### PR DESCRIPTION
This pull request introduces support for SQL state codes in error handling across the `sqllogictest` framework. The changes enhance error matching capabilities by incorporating SQL state codes, enabling more precise validation of expected errors. The updates span multiple modules, including error struct modifications, trait updates, and test enhancements.

### Enhancements to Error Handling:

* Updated the `EnginesError` struct in `sqllogictest-bin/src/engines.rs` to include an optional `sqlstate` field and added a `without_state` constructor for errors without SQL state codes. This change replaces the previous error mapping logic with `EnginesError::without_state` for MySQL, Postgres, and other engines. [[1]](diffhunk://#diff-b73c38016577055b31c7f998f793fa1b3ddbfd7dece64639e1d7f062efcd758fL76-R86) [[2]](diffhunk://#diff-b73c38016577055b31c7f998f793fa1b3ddbfd7dece64639e1d7f062efcd758fL101-R130)
* Introduced `error_sql_state` methods in the `AsyncDB` trait and its implementations for MySQL, Postgres (Simple and Extended), and other engines to extract SQL state codes from errors. [[1]](diffhunk://#diff-0c904667256cb927b1c08ce10854ecc9f13104f851d385c3ebf061994e2529ebR101-R105) [[2]](diffhunk://#diff-7a0a1ab111e4b38232cd3dcfde4465ca99302bc95c71522ab60a53532bc905bfR84-R91) [[3]](diffhunk://#diff-18599d7208a1e1dc8ee48be778017e0d3d2d0c0b84083a0954ef2bb429d44839R329-R332) [[4]](diffhunk://#diff-b76359335f8936a647d3c8cc463cf8e6924536ed0f4ed0b7c77a928cdd8de073R80-R83)

### SQL State Matching in Test Runner:

* Enhanced the `ExpectedError` enum in `sqllogictest/src/parser.rs` to support a new `SqlState` variant for matching errors based on SQL state codes. Updated parsing, formatting, and matching logic to handle this new variant. [[1]](diffhunk://#diff-96af14d8b4bc6bbe984894209b2dd749632c5993454bd76ef9314d30d678eb47R380-R401) [[2]](diffhunk://#diff-96af14d8b4bc6bbe984894209b2dd749632c5993454bd76ef9314d30d678eb47L409-R428) [[3]](diffhunk://#diff-96af14d8b4bc6bbe984894209b2dd749632c5993454bd76ef9314d30d678eb47L426-R451)
* Modified the test runner (`sqllogictest/src/runner.rs`) to utilize SQL state codes during error validation. Updated the `TestErrorKind::ErrorMismatch` variant to include the actual SQL state when applicable. [[1]](diffhunk://#diff-0c904667256cb927b1c08ce10854ecc9f13104f851d385c3ebf061994e2529ebL285-R306) [[2]](diffhunk://#diff-0c904667256cb927b1c08ce10854ecc9f13104f851d385c3ebf061994e2529ebL1115-R1144) [[3]](diffhunk://#diff-0c904667256cb927b1c08ce10854ecc9f13104f851d385c3ebf061994e2529ebL1154-R1187)

### Test Enhancements:

* Enhanced the `FakeDB` implementation in `tests/harness.rs` to generate errors with specific SQL state codes for various scenarios, such as syntax errors or missing columns. Added an `error_sql_state` method to retrieve SQL state codes from `FakeDBError`. [[1]](diffhunk://#diff-ebcb1bd9f67709a02eb3affe2b2a6b6fcadc672277de310cc7ee44f853d93f9cL16-R39) [[2]](diffhunk://#diff-ebcb1bd9f67709a02eb3affe2b2a6b6fcadc672277de310cc7ee44f853d93f9cL74-R150)

These changes improve the framework's ability to test database behavior with greater accuracy and flexibility by leveraging SQL state codes for error validation.